### PR TITLE
Adding resonance module

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,58 @@ plt.ylabel(r"$\phi(\lambda)$")
 ```
     
 ![png](https://raw.githubusercontent.com/BlackHolePerturbationToolkit/KerrGeoPy/main/README_files/Getting%20Started_20_1.png)
-    
+
+## Find resonant orbits
+### Double resonance
+Use `rtheta_resonance`, `rphi_resonance` and `phitheta_resonance` to find the semi-latus rectum $p$ of the corresponding resonance by passing the ratio, $a$, $e$ and $x$.
+
+```python
+kg.rtheta_resonance(9/10, 0.9, 0.6, 0.3)
+kg.rphi_resonance(9/10, 0.9, 0.6, 0.3)
+kg.phitheta_resonance(11/10, 0.9, 0.6, 0.3)
+```
+
+> [!NOTE]
+> While $r$-$\theta$ ratios and $r$-$\phi$ ratios are always less than 1, $\phi$-$\theta$ ratios can be larger than 1 if it is prograde, otherwise it is less than 1. $r$-$\theta$ ratios and $r$-$\phi$ ratios are actually negative in retrograde cases, but we take their absolute values so that every ratios are positive.
+
+### Triple resonant orbits
+
+Consider the triple resonance condition:
+$$
+    n_r\omega_r=n_\theta\omega_\theta=n_\phi\omega_\phi
+$$
+where $n_r$, $n_\theta$ and $n_\phi$ are the rational modes of corresponding frequencies. One of the ways of finding triple resonant orbits is finding possible value of one mode using two other given modes, $a$ and $e$. The functions used for this are `tripleResonance_thetaMode`, `tripleResonance_phiMode` and `tripleResonance_rMode`. By default, these function is in progade case.
+
+For example, with $(a, e, x)=(0.9, 0.6)$:
+- Finding $n_\theta$ if $n_r=10$ and $n_\phi=8$ 
+```python
+kg.tripleResonance_thetaMode(10, 8, 0.9, 0.6)
+```
+- Finding $n_\phi$ if $n_r=10$ and $n_\theta=8$ 
+```python
+kg.tripleResonance_phiMode(10, 8, 0.9, 0.6)
+```
+- Finding $n_r$ if $n_\theta=20$ and $n_\theta=19$ 
+```python
+kg.tripleResonance_rMode(10, 8, 0.9, 0.6)
+```
+
+Another way is finding $(p, x)$ of with the given 3 resonant modes using `tripleResonance`.
+```python
+kg.tripleResonance(10, 8.3, 8, 0.9, 0.6)
+```
+where $(n_r,n_\theta,n_\phi)=(10, 8.3, 8)$
+> [!CAUTION]
+> When using this module, because of the machine precision and the divergence of frequency ratios near the separatrix, you should not choose $r$-$\phi$ ratio or $r$-$\theta$ ratio that is too small (typically choose $\geq 1/3$), otherwise the functions don't work (A warning is raised when that happens). Similarly, the chosen $\phi$-$\theta$ ratio shouldn't be too far from 1.
+
+### Frequency ratio at the polar limit and the equatorial limit
+While most of the functions in this package does not support these limit, this module need them to find triple resonant orbits. For this reason, the limits are treated separately with 3 different ratios for each cases:
+- `rtheta_frequencyRatio_polarLimit`
+- `rphi_frequencyRatio_polarLimit`
+- `phitheta_frequencyRatio_polarLimit`
+- `rtheta_frequencyRatio_equatorialLimit`
+- `rphi_frequencyRatio_equatorialLimit`
+- `phitheta_frequencyRatio_equatorialLimit`
 ## Citation
 If you use this software, please cite our article in the Journal of Open Source Software.
 ```

--- a/docs/source/_autosummary/kerrgeopy.resonance.phitheta_resonance.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.phitheta_resonance.rst
@@ -1,0 +1,6 @@
+phitheta\_resonance
+===================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: phitheta_resonance

--- a/docs/source/_autosummary/kerrgeopy.resonance.rphi_frequencyRatio_equatorialLimit.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rphi_frequencyRatio_equatorialLimit.rst
@@ -1,0 +1,6 @@
+rphi\_frequencyRatio\_equatorialLimit
+=====================================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: rphi_frequencyRatio_equatorialLimit

--- a/docs/source/_autosummary/kerrgeopy.resonance.rphi_frequencyRatio_polarLimit.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rphi_frequencyRatio_polarLimit.rst
@@ -1,0 +1,6 @@
+rphi\_frequencyRatio\_polarLimit
+================================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: rphi_frequencyRatio_polarLimit

--- a/docs/source/_autosummary/kerrgeopy.resonance.rphi_resonance.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rphi_resonance.rst
@@ -1,0 +1,6 @@
+rphi\_resonance
+===============
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: rphi_resonance

--- a/docs/source/_autosummary/kerrgeopy.resonance.rphi_resonance_weakFieldLimit.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rphi_resonance_weakFieldLimit.rst
@@ -1,6 +1,0 @@
-rphi\_resonance\_weakFieldLimit
-===============================
-
-.. currentmodule:: kerrgeopy.resonance
-
-.. autofunction:: rphi_resonance_weakFieldLimit

--- a/docs/source/_autosummary/kerrgeopy.resonance.rphi_resonance_weakFieldLimit.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rphi_resonance_weakFieldLimit.rst
@@ -1,0 +1,6 @@
+rphi\_resonance\_weakFieldLimit
+===============================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: rphi_resonance_weakFieldLimit

--- a/docs/source/_autosummary/kerrgeopy.resonance.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rst
@@ -1,4 +1,4 @@
-﻿resonance
+resonance
 =========
 
 .. automodule:: kerrgeopy.resonance
@@ -19,11 +19,9 @@
       rphi_frequencyRatio_equatorialLimit
       rphi_frequencyRatio_polarLimit
       rphi_resonance
-      rphi_resonance_weakFieldLimit
       rtheta_frequencyRatio_equatorialLimit
       rtheta_frequencyRatio_polarLimit
       rtheta_resonance
-      rtheta_resonance_weakFieldLimit
       tripleResonance
       tripleResonance_phiMode
       tripleResonance_thetaMode

--- a/docs/source/_autosummary/kerrgeopy.resonance.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rst
@@ -1,0 +1,43 @@
+﻿resonance
+=========
+
+.. automodule:: kerrgeopy.resonance
+  
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree:
+      :template: custom-base-template.rst
+   
+      phitheta_resonance
+      rphi_frequencyRatio_equatorialLimit
+      rphi_frequencyRatio_polarLimit
+      rphi_resonance
+      rphi_resonance_weakFieldLimit
+      rtheta_frequencyRatio_equatorialLimit
+      rtheta_frequencyRatio_polarLimit
+      rtheta_resonance
+      rtheta_resonance_weakFieldLimit
+      tripleResonance
+      tripleResonance_phiMode
+      tripleResonance_thetaMode
+      valid_frequencyRatio
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/_autosummary/kerrgeopy.resonance.rtheta_frequencyRatio_equatorialLimit.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rtheta_frequencyRatio_equatorialLimit.rst
@@ -1,0 +1,6 @@
+rtheta\_frequencyRatio\_equatorialLimit
+=======================================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: rtheta_frequencyRatio_equatorialLimit

--- a/docs/source/_autosummary/kerrgeopy.resonance.rtheta_frequencyRatio_polarLimit.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rtheta_frequencyRatio_polarLimit.rst
@@ -1,0 +1,6 @@
+rtheta\_frequencyRatio\_polarLimit
+==================================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: rtheta_frequencyRatio_polarLimit

--- a/docs/source/_autosummary/kerrgeopy.resonance.rtheta_resonance.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rtheta_resonance.rst
@@ -1,0 +1,6 @@
+rtheta\_resonance
+=================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: rtheta_resonance

--- a/docs/source/_autosummary/kerrgeopy.resonance.rtheta_resonance_weakFieldLimit.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rtheta_resonance_weakFieldLimit.rst
@@ -1,6 +1,0 @@
-rtheta\_resonance\_weakFieldLimit
-=================================
-
-.. currentmodule:: kerrgeopy.resonance
-
-.. autofunction:: rtheta_resonance_weakFieldLimit

--- a/docs/source/_autosummary/kerrgeopy.resonance.rtheta_resonance_weakFieldLimit.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.rtheta_resonance_weakFieldLimit.rst
@@ -1,0 +1,6 @@
+rtheta\_resonance\_weakFieldLimit
+=================================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: rtheta_resonance_weakFieldLimit

--- a/docs/source/_autosummary/kerrgeopy.resonance.tripleResonance.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.tripleResonance.rst
@@ -1,0 +1,6 @@
+tripleResonance
+===============
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: tripleResonance

--- a/docs/source/_autosummary/kerrgeopy.resonance.tripleResonance_phiMode.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.tripleResonance_phiMode.rst
@@ -1,0 +1,6 @@
+tripleResonance\_phiMode
+========================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: tripleResonance_phiMode

--- a/docs/source/_autosummary/kerrgeopy.resonance.tripleResonance_thetaMode.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.tripleResonance_thetaMode.rst
@@ -1,0 +1,6 @@
+tripleResonance\_thetaMode
+==========================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: tripleResonance_thetaMode

--- a/docs/source/_autosummary/kerrgeopy.resonance.valid_frequencyRatio.rst
+++ b/docs/source/_autosummary/kerrgeopy.resonance.valid_frequencyRatio.rst
@@ -1,0 +1,6 @@
+valid\_frequencyRatio
+=====================
+
+.. currentmodule:: kerrgeopy.resonance
+
+.. autofunction:: valid_frequencyRatio

--- a/docs/source/_autosummary/kerrgeopy.rst
+++ b/docs/source/_autosummary/kerrgeopy.rst
@@ -33,6 +33,7 @@
    ~kerrgeopy.initial_conditions
    ~kerrgeopy.orbit
    ~kerrgeopy.plunge
+   ~kerrgeopy.resonance
    ~kerrgeopy.spacetime
    ~kerrgeopy.stable
    ~kerrgeopy.units

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2023, Seyong Park'
 author = 'Seyong Park'
 
 # The full version, including alpha/beta/rc tags
-release = '0.9.3'
+release = '0.9.4'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,6 +74,7 @@ API Reference
    ~kerrgeopy.constants
    ~kerrgeopy.frequencies
    ~kerrgeopy.initial_conditions
+   ~kerrgeopy.resonance
    ~kerrgeopy.units
 
 Indices and tables

--- a/kerrgeopy/__init__.py
+++ b/kerrgeopy/__init__.py
@@ -1,11 +1,12 @@
 """
 Python package for computing plunging and non-plunging geodesics in Kerr spacetime.
 """
-__all__ = ["units","constants", "frequencies","initial_conditions"]
+__all__ = ["units","constants", "frequencies","initial_conditions","resonance"]
 from kerrgeopy import *
 from kerrgeopy.frequencies import *
 from kerrgeopy.initial_conditions import *
 from kerrgeopy.constants import *
+from kerrgeopy.resonance import *
 from kerrgeopy.stable import StableOrbit
 from kerrgeopy.plunge import PlungingOrbit
 from kerrgeopy.orbit import Orbit

--- a/kerrgeopy/constants.py
+++ b/kerrgeopy/constants.py
@@ -36,12 +36,16 @@ def stable_radial_roots(a, p, e, x, constants=None):
         constants = constants_of_motion(a, p, e, x)
     E, L, Q = constants
 
-    r1 = p / (1 - e)
+    r1 = p / (1 - e) if e !=1 else inf
     r2 = p / (1 + e)
-
-    A_plus_B = 2 / (1 - E**2) - r1 - r2
-    AB = a**2 * Q / (r1 * r2 * (1 - E**2))
-
+    
+    if e == 1:
+        A_plus_B = (L**2+Q)/2-r2
+        AB = a**2 * Q / (2*r2)
+    else:
+        A_plus_B = 2 / (1 - E**2) - r1 - r2
+        AB = a**2 * Q / (r1 * r2 * (1 - E**2))
+        
     r3 = (A_plus_B + sqrt(A_plus_B**2 - 4 * AB)) / 2
     r4 = AB / r3
 
@@ -133,11 +137,17 @@ def stable_polar_roots(a, p, e, x, constants=None):
     if constants is None:
         constants = constants_of_motion(a, p, e, x)
     E, L, Q = constants
-    epsilon0 = a**2 * (1 - E**2) / L**2
     z_minus = 1 - x**2
-    # z_plus = a**2*(1-E**2)/(L**2*epsilon0)+1/(epsilon0*(1-z_minus))
-    # simplified using definition of carter constant
-    z_plus = nan if a == 0 else 1 + 1 / (epsilon0 * (1 - z_minus))
+    if (a == 0) | (e == 1):
+        z_plus = inf
+    else:
+        if x == 0:
+            z_plus = Q/a**2/(1-E**2)
+        else:
+            epsilon0 = a**2 * (1 - E**2) / L**2
+            # z_plus = a**2*(1-E**2)/(L**2*epsilon0)+1/(epsilon0*(1-z_minus))
+            # simplified using definition of carter constant
+            z_plus = 1 + 1 / (epsilon0 * (1 - z_minus))
 
     return z_minus, z_plus
 
@@ -700,7 +710,7 @@ def is_stable(a, p, e, x):
     -------
     boolean
     """
-    if p > separatrix(a, e, x):
+    if p >= separatrix(a, e, x):
         return True
     return False
 

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -5,181 +5,496 @@ from .frequencies import _ellippi
 from .constants import *
 from .constants import _standardize_params
 from scipy.optimize import fsolve, newton, root_scalar
-from scipy.special import elliprf, ellipk
-from numpy import sqrt, pi, sign
+from scipy.special import ellipk, elliprc
+from numpy import sqrt, pi, sign, exp
 
-def valid_integers(r, phi, theta):
+def valid_integers(r, theta, phi):
+    '''
+    Check if the three integers are valid 
+    '''
     if r < 0:
         return False
-    if (r!=0) & (phi!=0) & (theta!=0):
-        if (r<abs(phi)) & (r<abs(theta)):
+    if (r!=0) & (theta!=0) & (phi!=0):
+        if (r<abs(theta)) & (r<abs(phi)):
             return True
-    elif (r==0) & (phi!=0) & (theta!=0):
-        if phi*theta>0:
+    elif (r==0) & (theta!=0) & (phi!=0):
+        if (theta*phi>0) & (theta<phi):
             return True
-    elif (r!=0) & (phi==0) & (theta!=0):
-        if r<abs(theta):
-            return True
-    elif (r!=0) & (phi!=0) & (theta==0):
+    elif (r!=0) & (theta==0) & (phi!=0):
         if r<abs(phi):
+            return True
+    elif (r!=0) & (theta!=0) & (phi==0):
+        if r<abs(theta):
             return True
     else:
         return False
 
 # Frequency ratio functions
-## Needed functions
-def _r3r4_prod(a, p, e, x):
+## near-separatrix functions
+def _dr2_minus_dr3_ps(a, e, x, ps=None, constants=None):
     """
-    r3*r4
+    d(r_2-r_3)/dp evaluated at separatrix.
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ps : double
+        orbital semi-latus rectum at the separatrix
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrix
+        
+    Returns
+    -------
+    double
+    
     """
-    numerator_term1 = ((-4 + p) * p**7 + a**8 * (-1 + e**2)**4 * (-1 + x**2)**2 + 
-         2 * a**6 * (-1 + e**2)**2 * p * (1 - x**2) * ((1 + e**2) * p + (-2 + p + e**2 * (2 + p)) * (1 - x**2)) + 
-         a**4 * p**3 * ((-3 + 2 * e**2 + e**4) * p + 4 * (-4 + 3 * p + e**4 * (4 + p)) * (1 - x**2) + 
-         (-1 + e**2) * (-4 + e**2 * (-12 + p) + 3 * p) * (-1 + x**2)**2))
-    numerator_term2 =  ((-1 - e**2) * p**4 * (-2 + x**2) + 
-          8 * (-1 + e**2) * p**2 * (-1 + x**2) + 
-          2 * p**3 * (-3 - e**2 + 4 * (1 + e**2) * x**2))
-    numerator_term3 = (-1/(a**2*p))*(
-        (a**4*(-1 + e**2)**2 + 
-        (-4*e**2 + (-2 + p)**2)*p**2 + 
-        2*a**2*p*(-2 + p + e**2*(2 + p)))*x**2*(-p**2 + a**2*(-1 + e)**2*(-1 + x**2))*
-        (-p**2 + a**2*(1 + e)**2*(-1 + x**2))*(-p**2 + a**2*(-1 + e**2)*(-1 + x**2)))
-    if x>=0:
-        numerator = a**2*(1-x**2)*(numerator_term1+2*a**2*p**2*(numerator_term2-4*sqrt(numerator_term3)))
+    if not ps:
+        ps = separatrix(a,e,x)
+    if not constants:
+        constants = constants_of_motion(a, ps, e, x)   
+    r1, r2, r3, r4 = stable_radial_roots(a, ps, e, x, constants)
+    r3 = r2
+    S = r3+r4
+    P = r3*r4
+    A11 = (
+        4 * S * (a**2 * (e**2 - 1) * (e**2 - ps - 1) + ps * (e**2 * (ps + 4) - ps**2 + 3*ps - 4))
+        +8 * ps * (a**2 - ps) * (e**2 + ps - 1)
+        -8 * P * (e**2 + ps - 1)**2
+    )
+    A12 = (
+        4 * P * (a**2 * (e**2 - 1) * (e**2 - ps - 1) + ps * (e**2 * (ps + 4) - ps**2 + 3*ps - 4))
+        +2 * S * (-a**4 * (e**2 - 1)**2 - 2*a**2 * (e**2 - 1) * ps * (ps + 4) - (ps - 4)**2 * ps**2)
+        +4 * ps * (a**4 * (e**2 - 1) + a**2 * ps * (e**2 + ps + 3) + (ps - 4) * ps**2)
+    )
+    A21 = ps**2 - a**2 * (e**2 - 1) * (x**2 - 1)
+    A22 = 2 * a**2 * ps * (x**2 - 1)
+    B1 = (
+        8 * (e**2 - 1) * P * (P - 2*S)
+        +4 * ps**3 * (S - 2)**2
+        +4 * a**4 * (e**2 * (-S) + 2*ps + S)
+        +8 * ps * (-P * (e**2 * (S - 2) + 3*S + 2) + P**2 + 4*S**2)
+        +12 * ps**2 * (P * (S + 2) - 2*(S - 2)*S)
+        -4 * a**2 * (
+            3 * ps**2 * (S + 2) - 
+            (e**2 - 1) * (P * (S - 2) + 2*S**2) + 
+            ps * (S * (-(e**2 * (S - 2)) + S + 6) + 4*P)
+        )
+    )
+    B2 = -2 * (a**2 * (x**2 - 1) * (ps + S) + ps * P)
+    det = A11*A22-A12*A21
+    dP = (A22*B1-A12*B2)/det
+    dS = (-A21*B1+A11*B2)/det
+    return 1/(1+e)-(dP-r3*dS)/(S-2*r3)
+
+def _C(a, e, x,  ps=None, constants=None):
+    '''
+    (r_1-r_4)/(r_1-r_3)/(r_2-r_4) evaluated at separatrix p=p_s
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ps : double
+        orbital semi-latus rectum at the separatrix
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrix
+        
+    Returns
+    -------
+    double
+    
+    '''
+    if not ps:
+        ps = separatrix(a,e,x)
+    if not constants:
+        constants = constants_of_motion(a,ps,e,x)
+    r1, r2, r3, r4  = stable_radial_roots(a, ps, e, x, constants)
+    r3 = r2
+    if e == 1:
+        return 1/(r2-r4)
+    return (r1-r4)/(r1-r3)/(r2-r4)
+
+def _Frtheta(a, e, x, ps=None, constants=None):
+    '''
+    Frtheta= Upsilon_r/Upsilon_theta*K(k_r), evaluated at separatrix p=p_s
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ps : double
+        orbital semi-latus rectum at the separatrix
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrix
+        
+    Returns
+    -------
+    double
+    '''
+    if not ps:
+        ps = separatrix(a,e,x)
+    if not constants:
+        constants = constants_of_motion(a, ps, e, x)
+    E, L, Q = constants
+    r1, r2, r3, r4= stable_radial_roots(a, ps, e, x, constants)
+    r3 = r2
+    z_minus, z_plus = stable_polar_roots(a, ps, e, x, constants)
+    if e == 1:
+        return 2*sqrt(2*(r2-r4))/sqrt(L**2+Q)*pi/4
     else:
-        numerator = a**2*(1-x**2)*(numerator_term1+2*a**2*p**2*(numerator_term2+4*sqrt(numerator_term3)))
-    denominator = ((-4 + p)**2 * p**6 + a**8 * (-1 + e**2)**4 * (-1 + x**2)**2 + 
-         2 * a**2 * p**5 * ((-1 + e**2) * (4 + p) + (-4 + e**2 * (-12 + p) + 3 * p) * (1 - x**2)) + 
-         2 * a**6 * (-1 + e**2)**2 * p**2 * (-1 + x**2) * (-2 + 3 * x**2 + e**2 * (-2 + x**2)) + 
-         a**4 * p**3 * (-8 * (-1 + e**2)**2 * (1 - 3 * x**2 + 2 * x**4) + 
-         p * ((-1 + e**2)**2 - 4 * (-1 + e**4) * (-1 + x**2) + (3 + e**2)**2 * (-1 + x**2)**2)))
-
-    return numerator/denominator
-
-def _r3r4_prod_reduced(a, p, e, x):
-    """
-    r3*r4/(1-x^2)
-    """
-    numerator_term1 = ((-4 + p) * p**7 + a**8 * (-1 + e**2)**4 * (-1 + x**2)**2 + 
-         2 * a**6 * (-1 + e**2)**2 * p * (1 - x**2) * ((1 + e**2) * p + (-2 + p + e**2 * (2 + p)) * (1 - x**2)) + 
-         a**4 * p**3 * ((-3 + 2 * e**2 + e**4) * p + 4 * (-4 + 3 * p + e**4 * (4 + p)) * (1 - x**2) + 
-         (-1 + e**2) * (-4 + e**2 * (-12 + p) + 3 * p) * (-1 + x**2)**2))
-    numerator_term2 =  ((-1 - e**2) * p**4 * (-2 + x**2) + 
-          8 * (-1 + e**2) * p**2 * (-1 + x**2) + 
-          2 * p**3 * (-3 - e**2 + 4 * (1 + e**2) * x**2))
-    numerator_term3 = (-1/(a**2*p))*(
-        (a**4*(-1 + e**2)**2 + 
-        (-4*e**2 + (-2 + p)**2)*p**2 + 
-        2*a**2*p*(-2 + p + e**2*(2 + p)))*x**2*(-p**2 + a**2*(-1 + e)**2*(-1 + x**2))*
-        (-p**2 + a**2*(1 + e)**2*(-1 + x**2))*(-p**2 + a**2*(-1 + e**2)*(-1 + x**2)))
-    if x>=0:
-        numerator = a**2*(numerator_term1+2*a**2*p**2*(numerator_term2-4*sqrt(numerator_term3)))
+        return sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))*ellipk(z_minus/z_plus)
+    
+def _FK(a, e, x, ps=None, constants=None):
+    '''
+    Terms that have a common factor K(k_r) in Upsilon_phi/Upsilon_r, evaluated at separatrix.
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ps : double
+        orbital semi-latus rectum at the separatrix
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrix
+        
+    Returns
+    -------
+    double
+    
+    '''
+    if not ps:
+        ps = separatrix(a,e,x)
+    if not constants:
+        constants = constants_of_motion(a, ps, e, x)
+    E, L, Q = constants
+    r1, r2, r3, r4= stable_radial_roots(a, ps, e, x, constants)
+    r3 = r2
+    z_minus, z_plus = stable_polar_roots(a, ps, e, x, constants)
+    
+    r_plus = 1 + sqrt(1 - a**2)
+    r_minus = 1 - sqrt(1 - a**2)
+    
+    term1 = 1/_Frtheta(a, e, x, ps, constants)
+    
+    if e == 1:
+        term2 = 2*a/(pi*sqrt(2*(r2-r4)))*(2*E*r3-a*L)/(r3-r_plus)/(r3-r_minus)
+        if x==0:
+            return term1+term2, term1-term2
+        else:
+            return term1+sign(x)*term2
     else:
-        numerator = a**2*(numerator_term1+2*a**2*p**2*(numerator_term2+4*sqrt(numerator_term3)))
-    denominator = ((-4 + p)**2 * p**6 + a**8 * (-1 + e**2)**4 * (-1 + x**2)**2 + 
-         2 * a**2 * p**5 * ((-1 + e**2) * (4 + p) + (-4 + e**2 * (-12 + p) + 3 * p) * (1 - x**2)) + 
-         2 * a**6 * (-1 + e**2)**2 * p**2 * (-1 + x**2) * (-2 + 3 * x**2 + e**2 * (-2 + x**2)) + 
-         a**4 * p**3 * (-8 * (-1 + e**2)**2 * (1 - 3 * x**2 + 2 * x**4) + 
-         p * ((-1 + e**2)**2 - 4 * (-1 + e**4) * (-1 + x**2) + (3 + e**2)**2 * (-1 + x**2)**2)))
-    return numerator/denominator
-
-def _r3r4_sum(a, p, e, x):
-    if a != 0:
-        return (-p**2+a**2*(1-e**2)*(1-x**2))*(a**2-_r3r4_prod_reduced(a,p,e,x))/(2*a**2*p)
+        term2 = 2*a/(pi*sqrt((1-E**2)*(r1-r3)*(r2-r4)))*(2*E*r3-a*L)/(r3-r_plus)/(r3-r_minus)
+        if x == 0:
+            return term1+term2, term1-term2
+        else:
+            e0zp = (a**2 * (1 - E**2) * (1 - z_minus) + L**2) / (L**2 * (1 - z_minus))
+            return  2/(pi*sqrt(e0zp))*_ellippi(z_minus, z_minus/z_plus)*term1+sign(x)*term2
+        
+def _FPlus(a, e, x, ps=None, constants=None):
+    '''
+    Terms that have a common factor Pi(h_plus, k_r) in Upsilon_phi/Upsilon_r, evaluated at separatrix.
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ps : double
+        orbital semi-latus rectum at the separatrix
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrixs
+        
+    Returns
+    -------
+    double
+    
+    '''
+    if not ps:
+        ps = separatrix(a,e,x)
+    if not constants:
+        constants = constants_of_motion(a, ps, e, x)
+    E, L, Q = constants
+    r1, r2, r3, r4= stable_radial_roots(a, ps, e, x, constants)
+    r3 = r2
+    r_plus = 1 + sqrt(1 - a**2)
+    r_minus = 1 - sqrt(1 - a**2)
+    
+    if e == 1:
+        term1 = (
+            -2*a/(pi*sqrt(2*(r2-r4)))
+            *(2*E*r_plus-a*L)/(r3-r_plus)/(r_plus-r_minus)
+            *r3/r_plus
+        )
+        term2 = (r2-r4)/(r2-r_plus)
     else:
-        return 2*p/(p-4)
+        term1 = (
+            -2*a/(pi*sqrt((1-E**2)*(r1-r3)*(r2-r4)))
+            *(2*E*r_plus-a*L)/(r3-r_plus)/(r_plus-r_minus)
+            *(r1-r3)/(r1-r_plus)
+        )
+        term2 = (r1-r_plus)/(r2-r_plus)*(r2-r4)/(r1-r4) 
+    
+    # return term1*(log(2)+1/2*log(term2))
+    return term1*sqrt(term2)*elliprc(term2, 1)
 
-def _r3(a, p, e, x):
-    delta = _r3r4_sum(a,p,e,x)**2-4*_r3r4_prod(a,p,e,x)
-    return (_r3r4_sum(a,p,e,x)+sqrt(delta))/2
+def _FMinus(a, e, x, ps=None, constants=None):
+    '''
+    Terms that have a common factor Pi(h_minus, k_r) in Upsilon_phi/Upsilon_r, evaluated at separatrix.
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ps : double
+        orbital semi-latus rectum at the separatrix
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrix
+        
+    Returns
+    -------
+    double
+    
+    '''
+    if not ps:
+        ps = separatrix(a,e,x)
+    if not constants:
+        constants = constants_of_motion(a, ps, e, x)
+    E, L, Q = constants
+    r1, r2, r3, r4= stable_radial_roots(a, ps, e, x, constants)
+    r3 = r2
+    r_plus = 1 + sqrt(1 - a**2)
+    r_minus = 1 - sqrt(1 - a**2)
+    
+    if e == 1:
+        term1 = (
+            2*a/(pi*sqrt(2*(r2-r4)))
+            *(2*E*r_minus-a*L)/(r3-r_minus)/(r_plus-r_minus)
+            *r3/r_minus
+            )
+        term2 = (r2-r4)/(r2-r_minus)
+    else:
+        term1 = (
+            2*a/(pi*sqrt((1-E**2)*(r1-r3)*(r2-r4)))
+            *(2*E*r_minus-a*L)/(r3-r_minus)/(r_plus-r_minus)
+            *(r1-r3)/(r1-r_minus)
+        )
+        term2 = (r1-r_minus)/(r2-r_minus)*(r2-r4)/(r1-r4)
+    # return term1*(log(2)+1/2*log(term2))
+    return term1*sqrt(term2)*elliprc(term2, 1)
 
-def _r4(a, p, e, x):
-    delta = _r3r4_sum(a,p,e,x)**2-4*_r3r4_prod(a,p,e,x)
-    return (_r3r4_sum(a,p,e,x)-sqrt(delta))/2
+def _phitheta_boundRatio(a, e, x, ps=None, constants=None, xSign=None):
+    '''
+    Maximum/minimum of phi-theta frequency ratio of prograde/retrograde orbits.
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ps : double
+        orbital semi-latus rectum at the separatrix
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrix
+    xSign : float
+        sign of x (needed for polar orbits)
+        
+    Returns
+    -------
+    double
+    
+    '''
+    if not ps:
+        ps = separatrix(a,e,x)
+    if not constants:
+        constants = constants_of_motion(a, ps, e, x)
+    E, L, Q = constants
+    r1, r2, r3, r4= stable_radial_roots(a, ps, e, x, constants)
+    r3 = r2
+    z_minus, z_plus = stable_polar_roots(a, ps, e, x, constants)
+    
+    r_plus = 1 + sqrt(1 - a**2)
+    r_minus = 1 - sqrt(1 - a**2)
+    
+    term = (
+            2*a*ellipk(z_minus/z_plus)/(pi*sqrt(a**2*x**2*(1-E**2)+L**2+Q))
+            *(2*E*r3-a*L)/(r3-r_plus)/(r3-r_minus)
+        )
+    if x == 0:
+        if not xSign:
+            return 1+term, 1-term
+        else:
+            if xSign == 1:
+                return 1+term
+            elif xSign == -1:
+                return 1-term
 
-def _E2(a, p, e, x):
-    """
-    Squared energy
-    """
-    return 1-2*(1-e**2)/(2*p+(1-e**2)*_r3r4_sum(a,p,e,x))
+    else:
+        if e == 1:
+            return 1+sign(x)*term
+        else:
+            e0zp = (a**2 * (1 - E**2) * (1 - z_minus) + L**2) / (L**2 * (1 - z_minus))
+            return  2/(pi*sqrt(e0zp))*_ellippi(z_minus, z_minus/z_plus)+sign(x)*term
 
-def _L2(a, p, e, x):
-    """
-    Squared angular momentum
-    """
-    numerator = 2*(a**2*(-1+e**2)+p**2)*(a**2-_r3r4_prod(a,p,e,x))+4*a**2*p*_r3r4_sum(a,p,e,x)
-    denominator = a**2*(2*p+(1-e**2)*_r3r4_sum(a,p,e,x))
-    return numerator/denominator
 
-def _del1y1(a, p, e, x):
-    numerator = -e*p*sqrt(_r3r4_sum(a,p,e,x)**2-4*_r3r4_prod(a,p,e,x))
-    denominator = (1-e**2)*_r3r4_prod(a,p,e,x)+p**2-p*_r3r4_sum(a,p,e,x)
-    return numerator/denominator
+## near-separatrix initial guesses
 
-def _del2y2(a, p, e, x):
-    numerator = (1-e**2)*a**4*(1-x**2)
-    denominator = (1-e**2)*a**4*(1-x**2)-2*p**2*_r3r4_prod_reduced(a,p,e,x)
-    return numerator/denominator
+def _rtheta_nearSeparatrix_initialGuess(a, e, x, ratio, ps=None, constants=None):
+    '''
+    Initial guess of orbital semi-latus rectum for solving numerically r-theta resonance whose root is very close to the separatrix.
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ratio: double
+        r-theta frequency ratio
+    ps : double
+        orbital semi-latus rectum at the separatrix
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrix
+        
+    Returns
+    -------
+    double
+    
+    '''
+    if not ps:
+        ps = separatrix(a,e,x)
+    if e == 0:
+        return ps
+    if not constants:
+        constants = constants_of_motion(a, ps, e, x)
+    term = 16/_C(a,e,x,ps,constants)*exp(-2*_Frtheta(a,e,x,ps,constants)/abs(ratio))
+    return (
+        ps + 16/_dr2_minus_dr3_ps(a,e,x,ps,constants)/_C(a,e,x,ps,constants)
+            *exp(-2*_Frtheta(a,e,x,ps,constants)/abs(ratio))
+    )
 
-def _y1y2(a, p, e, x):
-    numerator = 2*a**2*((1-e**2)*_r3r4_prod(a,p,e,x)+p**2-p*_r3r4_sum(a,p,e,x))
-    denominator = a**4*(e**2-1)*(1-x**2)+2*p**2*_r3r4_prod_reduced(a,p,e,x)
-    return numerator/denominator
+def _rphi_nearSeparatrix_initialGuess(a, e, x, ratio, ps=None, constants=None):
+    '''
+    Initial guess of orbital semi-latus rectum for solving numerically r-phi resonance whose root is very close to the separatrix.
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ratio: double
+        r-phi frequency ratio
+    ps : double
+        orbital semi-latus rectum at the separatrix
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrix
+        
+    Returns
+    -------
+    double
+    
+    '''
+    if not ps:
+        ps = separatrix(a,e,x)
+    if e == 0:
+        return ps
+    if not constants:
+        constants = constants_of_motion(a, ps, e, x)
+    
+    if x == 0:
+        if ratio > 0:
+            FK = _FK(a,e,x,ps,constants)[0]
+        elif ratio < 0:
+            FK = _FK(a,e,x,ps,constants)[1]
+    else:
+        FK = _FK(a,e,x,ps,constants)
+    return (
+        ps + 16/_dr2_minus_dr3_ps(a,e,x,ps,constants)/_C(a,e,x,ps,constants)
+            *exp(2/FK*sign(ratio)*(_FPlus(a,e,x,ps,constants)+_FMinus(a,e,x,ps,constants)-1/ratio))
+    )
 
-def _kr(a,p,e,x):
-    numerator = (p-p*(1-e)/(1+e))*(_r3(a,p,e,x)-_r4(a,p,e,x))
-    denominator = (p-_r3(a,p,e,x)*(1-e))*(p/(1+e)-_r4(a,p,e,x))
-    return numerator/denominator
+def _phitheta_nearSeparatrix_initialGuess(a, e, x, ratio, ps=None, constants=None):
+    '''
+    Initial guess of orbital semi-latus rectum for solving numerically phi-theta resonance whose root is very close to the separatrix.
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    ratio: double
+        phi-theta frequency ratio
+    ps : double
+        orbital semi-latus rectum at the separatrix  
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit at the separatrix
+    Returns
+    -------
+    double
+    
+    '''
+    if not ps:
+        ps = separatrix(a,e,x)
+    if e == 0:
+        return ps
+    if not constants:
+        constants = constants_of_motion(a, ps, e, x)
 
-def _ktheta(a,p,e,x):
-    return (1-x**2)*(1-e**2)*a**4/(p**2*_r3r4_prod_reduced(a,p,e,x))
+    if x == 0:
+        if ratio > 1:
+            FK = _FK(a,e,x,ps,constants)[0]
+        elif ratio < 1:
+            FK = _FK(a,e,x,ps,constants)[1]
+    else:
+        FK = _FK(a,e,x,ps,constants)
+        
+    Frtheta = _Frtheta(a,e,x,ps,constants)
+    if ratio == FK*Frtheta:
+        return ps
+    else:
+        return (
+            ps + 16/_dr2_minus_dr3_ps(a,e,x,ps,constants)/_C(a,e,x,ps,constants)
+                *exp(2*Frtheta*(_FPlus(a,e,x,ps,constants)+_FMinus(a,e,x,ps,constants))
+                    /abs(FK*Frtheta-ratio))
+        ) 
 
-def _rPlus(a):
-    return 1+sqrt(1-a**2)
-
-def _rMinus(a):
-    return 1-sqrt(1-a**2)
-
-def _hPlus(a,p,e,x):
-    numerator = (p-p*(1-e)/(1+e))*(_r3(a,p,e,x)-_rPlus(a))
-    denominator = (p-_r3(a,p,e,x)*(1-e))*(p/(1+e)-_rPlus(a))
-    return numerator/denominator
-
-def _hMinus(a,p,e,x):
-    numerator = (p-p*(1-e)/(1+e))*(_r3(a,p,e,x)-_rMinus(a))
-    denominator = (p-_r3(a,p,e,x)*(1-e))*(p/(1+e)-_rMinus(a))
-    return numerator/denominator
-
-def _phiTerm_thetaPrefactor(a,p,e,x):
-    numerator = (a**2*(-1+e**2)+p**2)*(a**2-_r3r4_prod(a,p,e,x))+2*a**2*p*_r3r4_sum(a,p,e,x)
-    denominator = p**2*_r3r4_prod_reduced(a,p,e,x)
-    return 2/pi*sqrt(numerator/denominator)
-
-def _phiTerm_rPrefactor(a,p,e,x):
-    term1 = 2*a/(pi*(_rPlus(a)-_rMinus(a)))
-    term2_numerator = 2*p+(1-e**2)*_r3r4_sum(a,p,e,x)
-    term2_denominator = 2*(p-_r3(a,p,e,x)*(1-e))*(p-_r4(a,p,e,x)*(1+e))
-    return term1*sqrt(term2_numerator/term2_denominator)
-
-def _phiTerm_rPrefactorPlus(a,p,e,x):
-    term1 = (2*sqrt(_E2(a,p,e,x))*_rPlus(a)-a*sign(x)*sqrt(abs(_L2(a,p,e,x))))/(_r3(a,p,e,x)-_rPlus(a))
-    term2 = ellipk(_kr(a,p,e,x))-(p/(1+e)-_r3(a,p,e,x))/(p/(1+e)-_rPlus(a))*_ellippi(_hPlus(a,p,e,x),_kr(a,p,e,x))
-    return term1*term2
-
-def _phiTerm_rPrefactorMinus(a,p,e,x):
-    term1 = (2*sqrt(_E2(a,p,e,x))*_rMinus(a)-a*sign(x)*sqrt(abs(_L2(a,p,e,x))))/(_r3(a,p,e,x)-_rMinus(a))
-    term2 = ellipk(_kr(a,p,e,x))-(p/(1+e)-_r3(a,p,e,x))/(p/(1+e)-_rMinus(a))*_ellippi(_hMinus(a,p,e,x),_kr(a,p,e,x))
-    return term1*term2
-
-def _phiTerm_thetaTerm(a,p,e,x):
-    return _phiTerm_thetaPrefactor(a,p,e,x)*_ellippi(1-x**2,_ktheta(a,p,e,x))
-
-def _phiTerm_rTerm(a,p,e,x):
-    return _phiTerm_rPrefactor(a,p,e,x)*(_phiTerm_rPrefactorPlus(a,p,e,x)-_phiTerm_rPrefactorMinus(a,p,e,x))
-
-## frequency ratios
-def _rtheta_frequencyRatio(a, p, e, x):
-    """Ratio of r-frequency and theta-frequency  
+## general frequency ratios
+def _rtheta_frequencyRatio(a, p, e, x, constants=None):
+    """Ratio of r-frequency and theta-frequency times sign(x) 
 
     Parameters
     ----------
@@ -191,7 +506,9 @@ def _rtheta_frequencyRatio(a, p, e, x):
         orbital eccentricity
     x : double
         cosine of the orbital inclination
-
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit
+        
     Returns
     -------
     double
@@ -200,11 +517,106 @@ def _rtheta_frequencyRatio(a, p, e, x):
     
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
+    if not valid_params(a,e,x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
     if not is_stable(a,p,e,x):
         raise ValueError("Not a stable orbit")
-    return sqrt(_y1y2(a,p,e,x))*elliprf(0, 1+_del2y2(a,p,e,x), 1-_del2y2(a,p,e,x))/elliprf(0, 1+_del1y1(a,p,e,x), 1-_del1y1(a,p,e,x))
+    if p == separatrix(a,e,x):
+        return 0
+    
+    constants = constants_of_motion(a,p,e,x)
+    E, L, Q = constants
+    if a == 0:
+        return r_frequency(a,p,e,x,constants)/theta_frequency(a,p,e,x,constants)
+    if e == 1:
+        r1, r2, r3, r4 = stable_radial_roots(a, p, e, x, constants)
+        k_r = sqrt((r3-r4)/(r2-r4))
+        return 2*sqrt(2*(r2-r4))/sqrt(L**2+Q)*pi/4/ellipk(k_r**2)
+    
+    r1, r2, r3, r4 = stable_radial_roots(a, p, e, x, constants)
+    z_minus, z_plus= stable_polar_roots(a, p, e, x, constants)
+    k_r = sqrt((r1-r2)*(r3-r4) / ((r1-r3)*(r2-r4)))
+    k_theta = sqrt(z_minus/z_plus)
+    return sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))*ellipk(k_theta**2)/ellipk(k_r**2)
 
-def _rphi_frequencyRatio(a, p, e, x):
+def _rphi_frequencyRatio(a, p, e, x, constants=None):
+    """Ratio of r-frequency and phi-frequency times sign(x)
+
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+    constants : tuple(double, double, double)
+        dimensionless constants of motion for the orbit
+        
+    Returns
+    -------
+    double
+    """
+    a, x = _standardize_params(a, x)
+    
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if not valid_params(a,e,x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    if not is_stable(a,p,e,x):
+        raise ValueError("Not a stable orbit")
+    if p == separatrix(a,e,x):
+        return 0
+    
+    if not constants:
+        constants = constants_of_motion(a,p,e,x)
+    E, L, Q = constants
+    if a == 0:
+        return r_frequency(a,p,e,x,constants)/abs(phi_frequency(a,p,e,x,constants))
+    r1, r2, r3, r4 = stable_radial_roots(a, p, e, x, constants)
+    z_minus, z_plus = stable_polar_roots(a, p, e, x, constants)
+    r_plus = 1 + sqrt(1 - a**2)
+    r_minus = 1 - sqrt(1 - a**2)
+    
+    if e == 1:
+        k_r = sqrt((r3-r4)/(r2-r4))
+        h_plus =  (r3-r_plus)/(r2-r_plus)
+        h_minus = (r3-r_minus)/(r2-r_minus)
+        B_r = 2*a/(pi*(r_plus-r_minus)*sqrt(2*(r2-r4))
+        ) * (
+        (2*E*r_plus-a*L)/(r3-r_plus)
+        * (ellipk(k_r**2) - (r2-r3)/(r2-r_plus) * _ellippi(h_plus, k_r**2))
+        - (2*E*r_minus-a*L)/(r3-r_minus)
+        * (ellipk(k_r**2) - (r2-r3)/(r2-r_minus) * _ellippi(h_minus, k_r**2))
+        ) 
+        ratio_rtheta = 2*sqrt(2*(r2-r4))/sqrt(L**2+Q)*pi/4/ellipk(k_r**2)
+        if x == 0:
+            return 1/(1/ratio_rtheta+B_r), 1/(1/ratio_rtheta-B_r)
+        else:
+            return 1/(1/ratio_rtheta+sign(x)*B_r)
+        
+    k_r = sqrt((r1-r2)*(r3-r4) / ((r1-r3)*(r2-r4)))
+    h_plus =  (r1-r2)*(r3-r_plus) / ((r1-r3)*(r2-r_plus))
+    h_minus = (r1-r2)*(r3-r_minus) / ((r1-r3)*(r2-r_minus))
+    k_theta = sqrt(z_minus/z_plus)
+    B_r = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E**2)*(r1-r3)*(r2-r4))
+    ) * (
+    (2*E*r_plus-a*L)/(r3-r_plus)
+    * (ellipk(k_r**2) - (r2-r3)/(r2-r_plus) * _ellippi(h_plus, k_r**2))
+    - (2*E*r_minus-a*L)/(r3-r_minus)
+    * (ellipk(k_r**2) - (r2-r3)/(r2-r_minus) * _ellippi(h_minus, k_r**2))
+    ) 
+    ratio_rtheta = sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))*ellipk(k_theta**2)/ellipk(k_r**2)
+    if x == 0:
+        return 1/(1/ratio_rtheta+B_r), 1/(1/ratio_rtheta-B_r)
+    else: 
+        e0zp = (a**2 * (1 - E**2) * (1 - z_minus) + L**2) / (L**2 * (1 - z_minus))
+        B_theta = 2/(pi*sqrt(e0zp))*_ellippi(z_minus, z_minus/z_plus)
+        return  1/(B_theta/ratio_rtheta+sign(x)*B_r)
+    
+def _phitheta_frequencyRatio(a, p, e, x, constants=None):
     """Ratio of r-frequency and phi-frequency 
 
     Parameters
@@ -226,89 +638,110 @@ def _rphi_frequencyRatio(a, p, e, x):
     
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
+    if not valid_params(a,e,x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
     if not is_stable(a,p,e,x):
         raise ValueError("Not a stable orbit")
-    if x != 0: 
-        return sign(x)/(sign(x)*_phiTerm_thetaTerm(a,p,e,x)/_rtheta_frequencyRatio(a,p,e,x)+_phiTerm_rTerm(a,p,e,x))
-    else:
-        return [1/(1/_rtheta_frequencyRatio(a,p,e,x)+_phiTerm_rTerm(a,p,e,x)), -1/(-1/_rtheta_frequencyRatio(a,p,e,x)+_phiTerm_rTerm(a,p,e,x))]
-
-def _phitheta_frequencyRatio(a, p, e, x):
-    """Ratio of r-frequency and phi-frequency 
-
-    Parameters
-    ----------
-    a : double
-        dimensionless spin of the black hole
-    p : double
-        orbital semi-latus rectum
-    e : double
-        orbital eccentricity
-    x : double
-        cosine of the orbital inclination
-
-    Returns
-    -------
-    double
-    """
-    a, x = _standardize_params(a, x)
+    if p == separatrix(a,e,x):
+        return _phitheta_boundRatio(a, e, x)
+    if not constants:
+        constants = constants_of_motion(a,p,e,x)
+    E, L, Q = constants
+    if a == 0:
+        return phi_frequency(a,p,e,x,constants)/abs(theta_frequency(a,p,e,x,constants))
+    r1, r2, r3, r4 = stable_radial_roots(a, p, e, x, constants)
+    z_minus, z_plus = stable_polar_roots(a, p, e, x, constants)
+    r_plus = 1 + sqrt(1 - a**2)
+    r_minus = 1 - sqrt(1 - a**2)
     
-    if a == 1:
-        raise ValueError("Extreme Kerr not supported")
-    if not is_stable(a,p,e,x):
-        raise ValueError("Not a stable orbit")
-    if x != 0: 
-        return _phiTerm_thetaTerm(a,p,e,x)+sign(x)*_rtheta_frequencyRatio(a,p,e,x)*_phiTerm_rTerm(a,p,e,x)
-    else:
-        return [1+_rtheta_frequencyRatio(a,p,e,x)*_phiTerm_rTerm(a,p,e,x),1-_rtheta_frequencyRatio(a,p,e,x)*_phiTerm_rTerm(a,p,e,x)]
+    if e == 1:
+        k_r = sqrt((r3-r4)/(r2-r4))
+        h_plus =  (r3-r_plus)/(r2-r_plus)
+        h_minus = (r3-r_minus)/(r2-r_minus)
+        B_r = 2*a/(pi*(r_plus-r_minus)*sqrt(2*(r2-r4))
+        ) * (
+        (2*E*r_plus-a*L)/(r3-r_plus)
+        * (ellipk(k_r**2) - (r2-r3)/(r2-r_plus) * _ellippi(h_plus, k_r**2))
+        - (2*E*r_minus-a*L)/(r3-r_minus)
+        * (ellipk(k_r**2) - (r2-r3)/(r2-r_minus) * _ellippi(h_minus, k_r**2))
+        ) 
+        ratio_rtheta = 2*sqrt(2*(r2-r4))/sqrt(L**2+Q)*pi/4/ellipk(k_r**2)
+        if x == 0:
+            return 1+B_r*ratio_rtheta, 1-B_r*ratio_rtheta
+        else:
+            return 1+sign(x)*B_r*ratio_rtheta
 
-# Finding resonance
-## In general 
+    k_r = sqrt((r1-r2)*(r3-r4) / ((r1-r3)*(r2-r4)))
+    h_plus =  (r1-r2)*(r3-r_plus) / ((r1-r3)*(r2-r_plus))
+    h_minus = (r1-r2)*(r3-r_minus) / ((r1-r3)*(r2-r_minus))
+    k_theta = sqrt(z_minus/z_plus)
+    B_r = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E**2)*(r1-r3)*(r2-r4))
+    ) * (
+    (2*E*r_plus-a*L)/(r3-r_plus)
+    * (ellipk(k_r**2) - (r2-r3)/(r2-r_plus) * _ellippi(h_plus, k_r**2))
+    - (2*E*r_minus-a*L)/(r3-r_minus)
+    * (ellipk(k_r**2) - (r2-r3)/(r2-r_minus) * _ellippi(h_minus, k_r**2))
+    ) 
+    ratio_rtheta = sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))*ellipk(k_theta**2)/ellipk(k_r**2)
+    if x == 0:
+        return 1+B_r*ratio_rtheta, 1-B_r*ratio_rtheta
+    else: 
+        e0zp = (a**2 * (1 - E**2) * (1 - z_minus) + L**2) / (L**2 * (1 - z_minus))
+        B_theta = 2/(pi*sqrt(e0zp))*_ellippi(z_minus, k_theta**2)
+        return  B_theta+sign(x)*B_r*ratio_rtheta
 
-def _doubleResonance_solver(equation, p0, sep):
-    '''Try `scipy.newton` with two different initial guess, one of them is very near the separatrix. Also try solving by using `scipy.root_scalar(method="brentq")`
+# Finding double resonance
+## General solver
+def _doubleResonance_solver(equation, pWF, pNS, ps):
+    '''Try `scipy.newton` with two different initial guess to solve resonant condition for orbital semi-latus rectum,
+    one of them is very near the separatrix.
+    Also try using `scipy.root_scalar(method="brentq")`. If the root is very close to separatrix, approximate it to pNS.
     
     Parameters
     ----------
     equation: callable
         resonant condition equation needed to be solved
-    p0 : double
-        initial guess p of the first attemp
-    sep : double
-        initial guess p of the second attemp, which also is p at the separatrix
+    pWF : double
+        weak-field initial guess
+    pNS: double
+        near-separatrix initial guess
+    ps: double
+        orbital semi-latus rectum at the separatrix
     
     Returns
     -------
     p : double
         orbital semi-latus rectum
-    '''    
-    if p0 < sep:
+    '''
+    exceptErrors = (RuntimeError, ValueError)
+    if pWF > ps:
         try:
-            return newton(equation, sep+1e-5)
-        except (RuntimeError, ValueError):
+            return newton(equation, pWF)
+        except exceptErrors:
             pass
     try:
-        return newton(equation, p0)
-    except (RuntimeError, ValueError):
-        try:
-            return root_scalar(equation, method="brentq", bracket=(sep+1e-5, p0)).root
-        except:
-            try:
-                return newton(equation, sep+1e-5)
-            except (RuntimeError, ValueError):
-                pass
-    print("p is too close to the separatrix or no resonance. The result is set to sep+1e-5")
-    return sep+1e-5
+        return newton(equation, pNS)
+    except exceptErrors:
+        pass
+    try:    
+        return root_scalar(equation, bracket=[ps, (pNS-ps)/16*exp(pi)+ps], method="brentq").root
+    except exceptErrors:
+        pass
+    print("p is approximated to near-separatrix initial guess")
+    return pNS
 
-# find resonance
+
 ## r-theta resonance
 def _rtheta_resonance_p(a, e, x, rInteger, thetaInteger):
-    """Return p of r-theta resonant orbit
+    """Find p of r-theta resonant orbit with given (a,e,x,r-integer,theta-integer) such that
+    r-frequency/theta-frequency = r-integer/theta-integer
     
     Parameters
     ----------
-    ratio: double
-        r-theta frequency ratio
+    rInteger: integer
+        r-integer
+    thetaInteger: integer
+        theta-integer
     a : double
         dimensionless spin of the black hole
     e : double
@@ -324,39 +757,43 @@ def _rtheta_resonance_p(a, e, x, rInteger, thetaInteger):
     
     a, x = _standardize_params(a, x)
     if not valid_integers(rInteger, thetaInteger, 0):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported") 
     ratio = rInteger/thetaInteger
-    if sign(x)*sign(ratio)<0:
+    if (x != 0) & (sign(x) != sign(ratio)):
             raise ValueError("Require sign(x) = sign(rInteger/thetaInteger)")
-    return _doubleResonance_solver(lambda p: _rtheta_frequencyRatio(a, p, e, x)-abs(ratio),
-                                   6/(1-ratio**2),
-                                   separatrix(a, e, x))
+    ps = separatrix(a,e,x)
+    pWF = 6/(1-ratio**2)
+    pNS = _rtheta_nearSeparatrix_initialGuess(a,e,x,rInteger/thetaInteger,ps)
+    return _doubleResonance_solver(lambda p: _rtheta_frequencyRatio(a, p, e, x)*abs(thetaInteger)-rInteger,pWF,pNS,ps)
 
 def _rtheta_resonance_e(a, p, x, rInteger, thetaInteger):
-    """Return p of r-theta resonant orbit
+    """Find e of r-theta resonant orbit with given (a,p,x,r-integer,theta-integer) such that
+    r-frequency/theta-frequency = r-integer/theta-integer
     
     Parameters
     ----------
-    ratio: double
-        r-theta frequency ratio
+    rInteger: integer
+        r-integer
+    thetaInteger: integer
+        theta-integer
     a : double
         dimensionless spin of the black hole
-    e : double
-        orbital eccentricity
+    p : double
+        orbital semi-latus rectum
     x : double
         cosine of the orbital inclination
 
     Returns
     -------
-    p : double
-        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
     """
     
     a, x = _standardize_params(a, x)
     if not valid_integers(rInteger, thetaInteger, 0):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported") 
     ratio = rInteger/thetaInteger
@@ -372,32 +809,35 @@ def _rtheta_resonance_e(a, p, x, rInteger, thetaInteger):
     elif p == p1:
         return 1
     else:
-        e0 = (p-p0)/(p1-p0)
-        return newton(lambda e: _rtheta_frequencyRatio(a, p, e, x)-abs(ratio), e0)
+        e_guess = (p-p0)/(p1-p0)
+        return newton(lambda e: _rtheta_frequencyRatio(a, p, e, x)*abs(thetaInteger)-rInteger, e_guess)
 
 def _rtheta_resonance_x(a, p, e, rInteger, thetaInteger):
-    """Return p of r-theta resonant orbit
+    """Find x of r-theta resonant orbit with given (a,p,e,r-integer,theta-integer) such that
+    r-frequency/theta-frequency = r-integer/theta-integer
     
     Parameters
     ----------
-    ratio: double
-        r-theta frequency ratio
+    rInteger: integer
+        r-integer
+    thetaInteger: integer
+        theta-integer
     a : double
         dimensionless spin of the black hole
-    e : double
-        orbital eccentricity
-    x : double
-        cosine of the orbital inclination
-
-    Returns
-    -------
     p : double
         orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    
+    Returns
+    -------
+    x : double
+        cosine of the orbital inclination
     """
     
     a = abs(a)
     if not valid_integers(rInteger, thetaInteger, 0):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported") 
     ratio = rInteger/thetaInteger
@@ -415,18 +855,21 @@ def _rtheta_resonance_x(a, p, e, rInteger, thetaInteger):
     elif p == p1:
         return 1
     else:
-        x0 = Lz_sign*(p-p0)/(p1-p0)
-        return newton(lambda x: _rtheta_frequencyRatio(a, p, e, x)-abs(ratio), x0)
+        x_guess = Lz_sign*(p-p0)/(p1-p0)
+        return newton(lambda x: _rtheta_frequencyRatio(a, p, e, x)*abs(thetaInteger)-rInteger, x_guess)
+
 
 ## r-phi resonance
-
 def _rphi_resonance_p(a, e, x, rInteger, phiInteger):
-    """Return p of r-phi resonant orbit
-
+    """Find p of r-phi resonant orbit with given (a,e,x,r-integer,phi-integer) such that
+    r-frequency/phi-frequency = r-integer/phi-integer
+    
     Parameters
     ----------
-    ratio: double
-        r-phi frequency ratio
+    rInteger: integer
+        r-integer
+    phiInteger: integer
+        phi-integer
     a : double
         dimensionless spin of the black hole
     e : double
@@ -442,46 +885,50 @@ def _rphi_resonance_p(a, e, x, rInteger, phiInteger):
     
     a, x = _standardize_params(a, x)
     if not valid_integers(rInteger, 0, phiInteger):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     ratio = rInteger/phiInteger
     if x == 0:
         if ratio > 0:
-            resonantEquation = lambda p: _rphi_frequencyRatio(a, p, e, 0)[0]-abs(ratio)
+            resonantEquation = lambda p: _rphi_frequencyRatio(a, p, e, 0)[0]*abs(phiInteger)-rInteger
         elif ratio < 0:
-            resonantEquation = lambda p: _rphi_frequencyRatio(a, p, e, 0)[1]-abs(ratio)
+            resonantEquation = lambda p: _rphi_frequencyRatio(a, p, e, 0)[1]*abs(phiInteger)-rInteger
     else:
         if sign(x)*sign(ratio)<0:
             raise ValueError("Require sign(x) = sign(rInteger/phiInteger)")
-        resonantEquation = lambda p: _rphi_frequencyRatio(a, p, e, x)-abs(ratio)
-    p0 = 6/(1-ratio**2)
-    pSep = separatrix(a, e, x)
-    return _doubleResonance_solver(resonantEquation, p0, pSep)
+        resonantEquation = lambda p: _rphi_frequencyRatio(a, p, e, x)*abs(phiInteger)-rInteger
+    ps = separatrix(a,e,x)
+    pWF = 6/(1-ratio**2)
+    pNS = _rphi_nearSeparatrix_initialGuess(a,e,x,rInteger/phiInteger,ps)
+    return _doubleResonance_solver(resonantEquation,pWF,pNS,ps)
 
 def _rphi_resonance_e(a, p, x, rInteger, phiInteger):
-    """Return p of r-phi resonant orbit
-
+    """Find e of r-phi resonant orbit with given (a,p,x,r-integer,phi-integer) such that
+    r-frequency/phi-frequency = r-integer/phi-integer
+    
     Parameters
     ----------
-    ratio: double
-        r-phi frequency ratio
+    rInteger: integer
+        r-integer
+    phiInteger: integer
+        phi-integer
     a : double
         dimensionless spin of the black hole
-    e : double
-        orbital eccentricity
+    p : double
+        orbital semi-latus rectum
     x : double
         cosine of the orbital inclination
 
     Returns
     -------
-    p : double
-        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
     """
     
     a, x = _standardize_params(a, x)
     if not valid_integers(rInteger, 0, phiInteger):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     ratio = rInteger/phiInteger
@@ -494,41 +941,44 @@ def _rphi_resonance_e(a, p, x, rInteger, phiInteger):
         return 0
     if p == p1:
         return 1
-    e0 = (p-p0)/(p1-p0)
+    e_guess = (p-p0)/(p1-p0)
     if x == 0:
         if ratio > 0:
-            resonantEquation = lambda e: _rphi_frequencyRatio(a, p, e, x)[0]-abs(ratio)
+            resonantEquation = lambda e: _rphi_frequencyRatio(a, p, e, x)[0]*abs(phiInteger)-rInteger
         elif ratio < 0:
-            resonantEquation = lambda e: _rphi_frequencyRatio(a, p, e, x)[1]-abs(ratio)
+            resonantEquation = lambda e: _rphi_frequencyRatio(a, p, e, x)[1]*abs(phiInteger)-rInteger
     else:
         if sign(x)*sign(ratio)<0:
             raise ValueError("Require sign(x) = sign(rInteger/phiInteger)")
-        resonantEquation = lambda e: _rphi_frequencyRatio(a, p, e, x)-abs(ratio)
-    return newton(resonantEquation, e0)
+        resonantEquation = lambda e: _rphi_frequencyRatio(a, p, e, x)*abs(phiInteger)-rInteger
+    return newton(resonantEquation, e_guess)
 
 def _rphi_resonance_x(a, p, e, rInteger, phiInteger):
-    """Return p of r-phi resonant orbit
-
+    """Find x of r-phi resonant orbit with given (a,p,e,r-integer,phi-integer) such that
+    r-frequency/phi-frequency = r-integer/phi-integer
+    
     Parameters
     ----------
-    ratio: double
-        r-phi frequency ratio
+    rInteger: integer
+        r-integer
+    phiInteger: integer
+        phi-integer
     a : double
         dimensionless spin of the black hole
-    e : double
-        orbital eccentricity
-    x : double
-        cosine of the orbital inclination
-
-    Returns
-    -------
     p : double
         orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    
+    Returns
+    -------
+    x : double
+        cosine of the orbital inclination
     """
     
     a = abs(a)
     if not valid_integers(rInteger, 0, phiInteger):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     ratio = rInteger/phiInteger
@@ -545,19 +995,22 @@ def _rphi_resonance_x(a, p, e, rInteger, phiInteger):
         return 0
     if p == p1:
         return 1
-    x0 = Lz_sign*(p-p0)/(p1-p0)
-    resonantEquation = lambda x: _rphi_frequencyRatio(a, p, e, x)-abs(ratio)
-    return newton(resonantEquation, x0)
+    x_guess = Lz_sign*(p-p0)/(p1-p0)
+    resonantEquation = lambda x: _rphi_frequencyRatio(a, p, e, x)*abs(phiInteger)-rInteger
+    return newton(resonantEquation, x_guess)
+
 
 ## phi-theta resonance
-
 def _phitheta_resonance_p(a, e, x, thetaInteger, phiInteger):
-    """Return p of phi-theta resonant orbit
-
+    """Find p of phi-theta resonant orbit with given (a,e,x,theta-integer,phi-integer) such that
+    phi-frequency/theta-frequency = phi-integer/theta-integer
+    
     Parameters
     ----------
-    ratio: double
-        r-phi frequency ratio
+    thetaInteger: integer
+        theta-integer
+    phiInteger: integer
+        phi-integer
     a : double
         dimensionless spin of the black hole
     e : double
@@ -573,247 +1026,322 @@ def _phitheta_resonance_p(a, e, x, thetaInteger, phiInteger):
     
     a, x = _standardize_params(a, x)
     if not valid_integers(0, thetaInteger, phiInteger):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     if not valid_params(a, e, x):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    ratio = phiInteger/thetaInteger
+    if (x!=0) & (sign(x)!=sign(thetaInteger)):
+        raise ValueError("Require sign(x) = sign(phiInteger/thetaInteger-1)")
+    ps = separatrix(a,e,x)
+    bound = _phitheta_boundRatio(a, e, x, ps=ps, xSign=sign(thetaInteger))
+    if phiInteger == bound*thetaInteger:
+        return ps
+    elif not (thetaInteger<phiInteger) & (phiInteger<bound*thetaInteger):
+        print(f"No prograde (retrograde) resonace whose phi-theta ratio greater (lesser) than {bound}")
+        return nan
     if x == 0:
-        if ratio > 1:
-            resonantEquation = lambda p: _phitheta_frequencyRatio(a, p, e, 0)[0]-ratio
-        elif ratio < 1:
-            resonantEquation = lambda p: _phitheta_frequencyRatio(a, p, e, 0)[1]-ratio
+        if phiInteger/thetaInteger > 1:
+            resonantEquation = lambda p: _phitheta_frequencyRatio(a, p, e, 0)[0]*thetaInteger-phiInteger
+        elif phiInteger/thetaInteger < 1:
+            resonantEquation = lambda p: _phitheta_frequencyRatio(a, p, e, 0)[1]*thetaInteger-phiInteger
     else:
-        if sign(x)*sign(ratio-1)<0:
-            raise ValueError("Require sign(x) = sign(phiInteger/thetaInteger-1)")
-        resonantEquation = lambda p: _phitheta_frequencyRatio(a, p, e, x)-ratio
-    p0 = (2*a/abs(ratio-1))**(2/3)
-    pSep = separatrix(a, e, x)
-    return _doubleResonance_solver(resonantEquation, p0, pSep)
+        resonantEquation = lambda p: _phitheta_frequencyRatio(a, p, e, x)*thetaInteger-phiInteger
+    
+    pWF = (2*a/abs(phiInteger/thetaInteger-1))**(2/3)
+    pNS = _phitheta_nearSeparatrix_initialGuess(a,e,x,phiInteger/thetaInteger,ps)
+    return _doubleResonance_solver(resonantEquation,pWF,pNS,ps)
 
 def _phitheta_resonance_e(a, p, x, thetaInteger, phiInteger):
-    """Return p of r-phi resonant orbit
-
+    """Find e of phi-theta resonant orbit with given (a,p,x,theta-integer,phi-integer) such that
+    phi-frequency/theta-frequency = phi-integer/theta-integer
+    
     Parameters
     ----------
-    ratio: double
-        r-phi frequency ratio
+    thetaInteger: integer
+        theta-integer
+    phiInteger: integer
+        phi-integer
     a : double
         dimensionless spin of the black hole
-    e : double
-        orbital eccentricity
+    p : double
+        orbital semi-latus rectum
     x : double
         cosine of the orbital inclination
 
     Returns
     -------
-    p : double
-        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
     """
     
     a, x = _standardize_params(a, x)
     if not valid_integers(0, thetaInteger, phiInteger):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     ratio = phiInteger/thetaInteger
-    p0 = _phitheta_resonance_p(a, 0, x, thetaInteger, phiInteger)
+    if (x!=0) & (x*(ratio-1)<0):
+        raise ValueError("Require sign(x) = sign(phiInteger/thetaInteger-1)")
+    ratio_bound_0 = _phitheta_boundRatio(a, 0, x, xSign=sign(ratio-1))
+    ratio_bound_1 = _phitheta_boundRatio(a, 1, x, xSign=sign(ratio-1))
+    
+    if (thetaInteger<ratio_bound_1*thetaInteger) & (ratio_bound_1*thetaInteger<phiInteger):
+        print(f"No prograde (retrograde) resonace whose phi-theta ratio greater (lesser) than {ratio_bound_1}")
+        return nan
+    elif (thetaInteger<phiInteger) & (phiInteger<ratio_bound_0*thetaInteger):
+        e0 = 0
+        p0 = _phitheta_resonance_p(a, e0, x, thetaInteger, phiInteger)
+    elif (ratio_bound_0*thetaInteger<phiInteger) & (phiInteger<ratio_bound_1*thetaInteger):
+        e0 = root_scalar(lambda e: _phitheta_boundRatio(a,e,x,xSign=sign(ratio-1))-ratio, bracket=[0,1], method="brentq").root
+        p0 = separatrix(a,e0,x)
     p1 = _phitheta_resonance_p(a, 1, x, thetaInteger, phiInteger)
     if (p<p0)|(p1<p):
-        print(f"p must be in [{p0:f},{p1:f}]")
+        print(f"p must be in [{p0},{p1}]")
         return nan
-    if p == p0:
-        return 0
-    if p == p1:
+    elif p == p0:
+        return e0
+    elif p == p1:
         return 1
-    e0 = (p-p0)/(p1-p0)
+    else:
+        e_guess = (1-e0)*(p-p0)/(p1-p0)+e0
     if x == 0:
         if ratio > 1:
-            resonantEquation = lambda e: _phitheta_frequencyRatio(a, p, e, x)[0]-abs(ratio)
+            resonantEquation = lambda e: _phitheta_frequencyRatio(a, p, e, x)[0]*thetaInteger-phiInteger
         elif ratio < 1:
-            resonantEquation = lambda e: _phitheta_frequencyRatio(a, p, e, x)[1]-abs(ratio)
+            resonantEquation = lambda e: _phitheta_frequencyRatio(a, p, e, x)[1]*thetaInteger-phiInteger
     else:
-        if sign(x)*sign(ratio-1)<0:
-            raise ValueError("Require sign(x) = sign(phiInteger/thetaInteger-1)")
-        resonantEquation = lambda e: _phitheta_frequencyRatio(a, p, e, x)-abs(ratio)
-    return newton(resonantEquation, e0)
-
+        resonantEquation = lambda e: _phitheta_frequencyRatio(a, p, e, x)*thetaInteger-phiInteger
+    try:
+        return newton(resonantEquation, e_guess)
+    except (ValueError):
+        print(f"p is very close to separatrix, it is between {p0} and {p1}")
+        return nan
+    
 def _phitheta_resonance_x(a, p, e, thetaInteger, phiInteger):
-    """Return p of r-phi resonant orbit
-
+    """Find x of phi-theta resonant orbit with given (a,p,e,theta-integer,phi-integer) such that
+    phi-frequency/theta-frequency = phi-integer/theta-integer
+    
     Parameters
     ----------
-    ratio: double
-        r-phi frequency ratio
+    thetaInteger: integer
+        theta-integer
+    phiInteger: integer
+        phi-integer
     a : double
         dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
     e : double
         orbital eccentricity
-    x : double
-        cosine of the orbital inclination
 
     Returns
     -------
-    p : double
-        orbital semi-latus rectum
+    x : double
+        cosine of the orbital inclination
+    
     """
     
     a = abs(a)
     
     if not valid_integers(0, thetaInteger, phiInteger):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     ratio = phiInteger/thetaInteger
-    Lz_sign = sign(ratio-1)
-    p0 = _phitheta_resonance_p(a, e, 0, thetaInteger, phiInteger)
-    p1 = _phitheta_resonance_p(a, e, Lz_sign, thetaInteger, phiInteger)
-    if (ratio>1)&((p<p1)|(p0<p)):
-        print(f"p must be in [{p1:f},{p0:f}]")
+    ratio_bound_0 = _phitheta_boundRatio(a, e, 0, xSign=sign(ratio-1))
+    ratio_bound_1 = _phitheta_boundRatio(a, e, sign(ratio-1), xSign=sign(ratio-1))
+    if ratio > 1:
+        if phiInteger > thetaInteger*ratio_bound_1:
+            raise ValueError("No resonance")
+        elif thetaInteger*ratio_bound_0 < phiInteger < thetaInteger*ratio_bound_1:
+            x0 = root_scalar(lambda x: _phitheta_boundRatio(a, e, x, xSign=1)*thetaInteger-phiInteger, bracket=[0,1], method="brentq").root
+            p0 = separatrix(a, e, x0)
+            x1 = 1
+            p1 = _phitheta_resonance_p(a, e, x1, thetaInteger, phiInteger)
+            x_guess = (1-x0)*(p-p0)/(p1-p0)+x0
+        elif phiInteger < thetaInteger*ratio_bound_0:
+            x0 = 0
+            p0 = _phitheta_resonance_p(a, e, x0, thetaInteger, phiInteger)
+            x1 = 1
+            p1 = _phitheta_resonance_p(a, e, x1, thetaInteger, phiInteger)
+            x_guess = (p-p0)/(p1-p0)
+        if (p<p1)|(p0<p):
+            print(f"p must be in [{p1},{p0}]")
+            return nan   
+    elif ratio < 1:
+        if phiInteger > thetaInteger*ratio_bound_0:
+            raise ValueError("No resonance")
+        elif thetaInteger*ratio_bound_1 < phiInteger < thetaInteger*ratio_bound_0:
+            x1 = root_scalar(lambda x: _phitheta_boundRatio(a, e, x, xSign=-1)*thetaInteger-phiInteger, bracket=[-1,0], method="brentq").root
+            p1 = separatrix(a,e,x1)
+            x0 = 0
+            p0 = _phitheta_resonance_p(a, e, x0, thetaInteger, phiInteger)
+            x_guess = -x1*(p-p1)/(p0-p1)+x1
+        elif phiInteger < thetaInteger*ratio_bound_1:
+            x1 = -1
+            p1 = _phitheta_resonance_p(a, e, x1, thetaInteger, phiInteger)
+            x0 = 0
+            p0 = _phitheta_resonance_p(a, e, x0, thetaInteger, phiInteger)
+            x_guess = -(p-p0)/(p1-p0)
+        if (p<p0)|(p1<p): 
+            print(f"p must be in [{p0},{p1}]")
+            return nan
+    if (p==p1): return x1
+    if (p==p0): return x0
+    try:
+        return newton(lambda x: _phitheta_frequencyRatio(a,p,e,x)*thetaInteger-phiInteger, x_guess)
+    except (ValueError):
+        print(f"p is very close to separatrix, x is between {x0} and {x1}")
         return nan
-    if (ratio<1)&((p<p0)|(p1<p)):
-        print(f"p must be in [{p0:f},{p1:f}]")
-        return nan
-    if p == p0:
-        return 0
-    if p == p1:
-        return 1
-    x0 = Lz_sign*(p-p0)/(p1-p0)
-    resonantEquation = lambda x: _phitheta_frequencyRatio(a, p, e, x)-abs(ratio)
-    return newton(resonantEquation, x0)
+    
 
 # Finding triple resonance
-def _tripleResonance_rInteger(thetaInteger, phiInteger, a, e):
-    """Find possible r-integers sastify omega_r:omega_theta:omega_phi = r-integer:theta-integer:phi-integer.
+
+## Given (a,e)
+def _tripleResonance_px_rInteger(thetaInteger, phiInteger, a, e):
+    """Find possible r-integer sastify
+    
+    r-frequency:theta-frequency:phi-frequency=r-integer:theta-integer:phi-integer.
 
     Parameters
     ----------
-    rMode : double
-        radial mode
-    phiMode : double
-        azimuthal-angle mode
+    thetaInteger : double
+        theta-integer
+    phiInteger : double
+        phi-integer
     a : double
         dimensionless spin of the black hole
     e : double
         orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
     
     Returns
     ------- 
     (double, double)
-        Boundaries of the posible theta-mode.
+        The range of posible r-integers.
     """
         
     a = abs(a)
-    phitheta_ratio = phiInteger/thetaInteger
-    Lz_sign = sign(phitheta_ratio-1)
     
     if not valid_integers(0, thetaInteger, phiInteger):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    phitheta_ratio = phiInteger/thetaInteger
+    xSign = sign(phiInteger/thetaInteger-1)
+    ratio_bound_0 = _phitheta_boundRatio(a,e,0,xSign=xSign)
+    ratio_bound_1 = _phitheta_boundRatio(a,e,xSign)
+        
+    if phitheta_ratio > 1:
+        if phiInteger > thetaInteger*ratio_bound_1:
+            raise ValueError("No resonance")
+        elif thetaInteger*ratio_bound_0 < phiInteger < thetaInteger*ratio_bound_1:
+            p1 = _phitheta_resonance_p(a, e, xSign, thetaInteger, phiInteger)
+            rtheta_ratio1 = _rtheta_frequencyRatio(a,p1,e,xSign)
+            return [0, rtheta_ratio1*abs(thetaInteger)]
+            
+        elif phiInteger < thetaInteger*ratio_bound_0:
+            p0 = _phitheta_resonance_p(a, e, 0, thetaInteger, phiInteger)
+            p1 = _phitheta_resonance_p(a, e, xSign, thetaInteger, phiInteger)
+            rtheta_ratio0 = _rtheta_frequencyRatio(a, p0, e, 0)
+            rtheta_ratio1 = _rtheta_frequencyRatio(a, p1, e, xSign)
+            return [abs(thetaInteger)*rtheta_ratio0, abs(thetaInteger)*rtheta_ratio1]
 
-    p0 = _phitheta_resonance_p(a, e, 0, thetaInteger, phiInteger)
-    p1 = _phitheta_resonance_p( a, e, Lz_sign, thetaInteger, phiInteger)
-    rtheta_ratio0 = _rtheta_frequencyRatio(a, p0, e, 0)
-    rtheta_ratio1 = _rtheta_frequencyRatio(a, p1, e, Lz_sign)
+    elif phitheta_ratio < 1:
+        if phiInteger > thetaInteger*ratio_bound_0:
+            raise ValueError("No resonance")
+        elif thetaInteger*ratio_bound_1 < phiInteger < thetaInteger*ratio_bound_0:
+            p0 = _phitheta_resonance_p(a, e, 0, thetaInteger, phiInteger)
+            rtheta_ratio0 = _rtheta_frequencyRatio(a, p0, e, 0)
+            return [0, rtheta_ratio0*abs(thetaInteger)]
+        elif phiInteger < thetaInteger*ratio_bound_1:
+            p0 = _phitheta_resonance_p(a, e, 0, thetaInteger, phiInteger)
+            p1 = _phitheta_resonance_p(a, e, xSign, thetaInteger, phiInteger)
+            rtheta_ratio0 = _rtheta_frequencyRatio(a, p0, e, 0)
+            rtheta_ratio1 = _rtheta_frequencyRatio(a, p1, e, xSign)
+            return sorted([abs(thetaInteger)*rtheta_ratio1, abs(thetaInteger)*rtheta_ratio0])
+
+def _tripleResonance_px_thetaInteger(rInteger, phiInteger, a, e):
+    """Find possible theta-integer sastify
     
-    return sorted([thetaInteger*rtheta_ratio0, thetaInteger*rtheta_ratio1])
-
-def _tripleResonance_thetaInteger(rInteger, phiInteger, a, e):
-    """Find possible theta-integers sastify omega_r:omega_theta:omega_phi = r-integer:theta-integer:phi-integer.
+    r-frequency:theta-frequency:phi-frequency=r-integer:theta-integer:phi-integer.
 
     Parameters
     ----------
-    rMode : double
-        radial mode
-    phiMode : double
-        azimuthal-angle mode
+    rInteger : double
+        r-integer
+    phiInteger : double
+        theta-integer
     a : double
         dimensionless spin of the black hole
     e : double
         orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
     
     Returns
     ------- 
     (double, double)
-        Boundaries of the posible theta-mode.
+        The range of posible theta-integers.
     """
         
     a = abs(a)
-    rphi_ratio = rInteger/phiInteger
-    Lz_sign = sign(rphi_ratio)
     
     if not valid_integers(rInteger, 0, phiInteger):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
     p0 = _rphi_resonance_p(a, e, 0, rInteger, phiInteger)
-    p1 = _rphi_resonance_p(a, e, Lz_sign, rInteger, phiInteger)
+    p1 = _rphi_resonance_p(a, e, sign(phiInteger), rInteger, phiInteger)
     rtheta_ratio0 = _rtheta_frequencyRatio(a, p0, e, 0)
-    rtheta_ratio1 = _rtheta_frequencyRatio(a, p1, e, Lz_sign)
+    rtheta_ratio1 = _rtheta_frequencyRatio(a, p1, e, sign(phiInteger))
     
     return sorted([rInteger/rtheta_ratio0, rInteger/rtheta_ratio1])
 
-def _tripleResonance_phiInteger(rInteger, thetaInteger, a, e):
-    """Find possible phi-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
+def _tripleResonance_px_phiInteger(rInteger, thetaInteger, a, e):
+    """Find possible phi-integer sastify
+    
+    r-frequency:theta-frequency:phi-frequency=r-integer:theta-integer:phi-integer.
 
     Parameters
     ----------
-    rMode : double
-        radial mode
-    thetaMode : double
-        polar-angle mode
+    rInteger : double
+        r-integer
+    thetaInteger : double
+        theta-integer
     a : double
         dimensionless spin of the black hole
     e : double
         orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
     
     Returns
     ------- 
     (double, double)
-        Boundaries of the posible phi-mode.
+        The range of posible phi-integers.
     """
         
     a = abs(a)
-    rtheta_ratio = rInteger/thetaInteger
-    Lz_sign = rtheta_ratio
-    
     if not valid_integers(rInteger, thetaInteger, 0):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
     p0 = _rtheta_resonance_p(a, e, 0, rInteger, thetaInteger)
-    p1 = _rtheta_resonance_p(a, e, Lz_sign, rInteger, thetaInteger)
-    if Lz_sign > 0:
+    p1 = _rtheta_resonance_p(a, e, sign(thetaInteger), rInteger, thetaInteger)
+    if thetaInteger > 0:
         rphi_ratio0 = _rphi_frequencyRatio(a, p0, e, 0)[0]
-    elif Lz_sign < 0:
+    elif thetaInteger < 0:
         rphi_ratio0 = _rphi_frequencyRatio(a, p0, e, 0)[1]
-    rphi_ratio1 = _rphi_frequencyRatio(a, p1, e, Lz_sign)
+    rphi_ratio1 = _rphi_frequencyRatio(a, p1, e, sign(thetaInteger))
     
     return sorted([rInteger/rphi_ratio0, rInteger/rphi_ratio1])
 
-def _tripleResonance(a, e, rInteger, thetaInteger, phiInteger):
+def _tripleResonance_px(a, e, rInteger, thetaInteger, phiInteger):
     """Find (p, x) from resonant modes
 
     Parameters
@@ -828,8 +1356,6 @@ def _tripleResonance(a, e, rInteger, thetaInteger, phiInteger):
         dimensionless spin of the black hole
     e : double
         orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
     
     Returns
     ------- 
@@ -838,12 +1364,10 @@ def _tripleResonance(a, e, rInteger, thetaInteger, phiInteger):
     """
     
     a = abs(a)
-    rtheta_ratio = rInteger/thetaInteger
-    rphi_ratio = rInteger/phiInteger
-    Lz_sign = sign(rtheta_ratio)
+    xSign = sign(thetaInteger)
     
     if not valid_integers(rInteger, thetaInteger, phiInteger):
-        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     if e == 1:
@@ -852,42 +1376,235 @@ def _tripleResonance(a, e, rInteger, thetaInteger, phiInteger):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")  
 
     p0_rtheta = _rtheta_resonance_p(a, e, 0, rInteger, thetaInteger)
-    p1_rtheta = _rtheta_resonance_p(a, e, Lz_sign, rInteger, thetaInteger)
+    p1_rtheta = _rtheta_resonance_p(a, e, xSign, rInteger, thetaInteger)
     p0_rphi = _rphi_resonance_p(a, e, 0, rInteger, phiInteger)
-    p1_rphi = _rphi_resonance_p(a, e, Lz_sign, rInteger, phiInteger)
+    p1_rphi = _rphi_resonance_p(a, e, xSign, rInteger, phiInteger)
                                    
     check_if_having_solution = (p0_rtheta-p0_rphi)*(p1_rtheta-p1_rphi)
     
     if (check_if_having_solution > 0) | (check_if_having_solution == nan):
-        rs = _tripleResonance_rInteger(thetaInteger, phiInteger, a, e)
-        thetas = _tripleResonance_phiInteger(rInteger, thetaInteger, a, e)
-        phis = _tripleResonance_thetaInteger(rInteger, phiInteger, a, e)
+        rs = _tripleResonance_px_rInteger(thetaInteger, phiInteger, a, e)
+        thetas = _tripleResonance_px_thetaInteger(rInteger, phiInteger, a, e)
+        phis = _tripleResonance_px_phiInteger(rInteger, thetaInteger, a, e)
         print("No triple resonance, try changing one of the integers:")
-        print(f"Choose r-integer in [{rs[0]:f}, {rs[1]:f}]")
-        print(f"Choose phi-integer in [{thetas[0]:f}, {thetas[1]:f}]")
-        print(f"Choose theta-integer in [{phis[0]:f}, {phis[1]:f}]")
+        print(f"Choose r-integer in {rs}")
+        print(f"Choose theta-integer in {thetas}]")
+        print(f"Choose phi-integer in {phis}")
         return [nan, nan]
     elif check_if_having_solution < 0:
-        x0 = Lz_sign/((p1_rphi-p1_rtheta)/(p0_rtheta-p0_rphi)+1)
-        p0 = p0_rtheta-Lz_sign*x0*(p0_rtheta-p1_rtheta)
-        sol = fsolve(lambda X: [_rtheta_frequencyRatio(a, X[0], e, X[1])-abs(rtheta_ratio),
-                                _rphi_frequencyRatio(a, X[0], e, X[1])-abs(rphi_ratio)], [p0, x0])
+        x0 = xSign/((p1_rphi-p1_rtheta)/(p0_rtheta-p0_rphi)+1)
+        p0 = p0_rtheta-xSign*x0*(p0_rtheta-p1_rtheta)
+        sol = fsolve(lambda X: [_rtheta_frequencyRatio(a, X[0], e, X[1])*abs(thetaInteger)-rInteger,
+                                _rphi_frequencyRatio(a, X[0], e, X[1])*abs(phiInteger)-rInteger], [p0, x0])
         return sol
     else:
         if (p0_rtheta-p0_rphi) == 0:
-            return [p0_rtheta, Lz_sign]
-        else:
-            return [p1_rtheta, 0]
-        
-# Generic function
+            return [p0_rtheta, 0]
+        elif (p1_rtheta-p1_rphi) == 0:
+            return [p1_rtheta, xSign]
 
+## Given (a,x)
+def _tripleResonance_pe_rInteger(thetaInteger, phiInteger, a, x):
+    """Find possible r-integer sastify
+    
+    r-frequency:theta-frequency:phi-frequency=r-integer:theta-integer:phi-integer.
+
+    Parameters
+    ----------
+    thetaInteger : double
+        theta-integer
+    phiInteger : double
+        phi-integer
+    a : double
+        dimensionless spin of the black hole
+    x : double
+        cosine of the orbital inclination
+    
+    Returns
+    ------- 
+    (double, double)
+        The range of posible r-integers.
+    """
+        
+    a = abs(a)
+    
+    if not valid_integers(0, thetaInteger, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if not valid_params(a, .5, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    phitheta_ratio = phiInteger/thetaInteger
+    xSign = sign(phiInteger/thetaInteger-1)
+    ratio_bound_0 = _phitheta_boundRatio(a,0,x,xSign=xSign)
+    ratio_bound_1 = _phitheta_boundRatio(a,1,x,xSign=xSign)
+    
+    if (thetaInteger<ratio_bound_1*thetaInteger) & (ratio_bound_1*thetaInteger<phiInteger):
+        print(f"No prograde (retrograde) resonace whose phi-theta ratio greater (lesser) than {ratio_bound_1}")
+        return nan
+    elif (thetaInteger<phiInteger) & (phiInteger<ratio_bound_0*thetaInteger):
+        p0 = _phitheta_resonance_p(a, 0, x, thetaInteger, phiInteger)
+        p1 = _phitheta_resonance_p(a, 1, x, thetaInteger, phiInteger)
+        rtheta_ratio0 = _rtheta_frequencyRatio(a, p0, 0, x)
+        rtheta_ratio1 = _rtheta_frequencyRatio(a, p1, 1, x)
+        return [abs(thetaInteger)*rtheta_ratio0, abs(thetaInteger)*rtheta_ratio1]
+        
+    elif (ratio_bound_0*thetaInteger<phiInteger) & (phiInteger<ratio_bound_1*thetaInteger):
+        p1 = _phitheta_resonance_p(a, 1, x, thetaInteger, phiInteger)
+        rtheta_ratio1 = _rtheta_frequencyRatio(a, p1, 1, x)
+        return [0, abs(thetaInteger)*rtheta_ratio1]
+
+def _tripleResonance_pe_thetaInteger(rInteger, phiInteger, a, x):
+    """Find possible theta-integer sastify
+    
+    r-frequency:theta-frequency:phi-frequency=r-integer:theta-integer:phi-integer.
+
+    Parameters
+    ----------
+    rInteger : double
+        r-integer
+    phiInteger : double
+        theta-integer
+    a : double
+        dimensionless spin of the black hole
+    x : double
+        cosine of orbital inclination
+    
+    Returns
+    ------- 
+    (double, double)
+        The range of posible theta-integers.
+    """
+        
+    a = abs(a)
+    
+    if not valid_integers(rInteger, 0, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if phiInteger*x<0:
+        raise ValueError("Require phiInteger*x>=0")
+    if not valid_params(a, 0.5, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+
+    p0 = _rphi_resonance_p(a, 0, x, rInteger, phiInteger)
+    p1 = _rphi_resonance_p(a, 1, x, rInteger, phiInteger)
+    rtheta_ratio0 = sign(phiInteger)*_rtheta_frequencyRatio(a, p0, 0, x)
+    rtheta_ratio1 = sign(phiInteger)*_rtheta_frequencyRatio(a, p1, 1, x)
+    
+    return sorted([rInteger/rtheta_ratio0, rInteger/rtheta_ratio1])
+
+def _tripleResonance_pe_phiInteger(rInteger, thetaInteger, a, x):
+    """Find possible phi-integer sastify
+    
+    r-frequency:theta-frequency:phi-frequency=r-integer:theta-integer:phi-integer.
+
+    Parameters
+    ----------
+    rInteger : double
+        r-integer
+    thetaInteger : double
+        theta-integer
+    a : double
+        dimensionless spin of the black hole
+    x : double
+        cosine of orbital inclination
+    
+    Returns
+    ------- 
+    (double, double)
+        The range of posible theta-integers.
+    """
+        
+    a = abs(a)
+    
+    if not valid_integers(rInteger, thetaInteger, 0):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if thetaInteger*x<0:
+        raise ValueError("Require thetaInteger*x>=0")
+    if not valid_params(a, 0.5, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+
+    p0 = _rtheta_resonance_p(a, 0, x, rInteger, thetaInteger)
+    p1 = _rtheta_resonance_p(a, 1, x, rInteger, thetaInteger)
+    rphi_ratio0 = sign(thetaInteger)*_rphi_frequencyRatio(a, p0, 0, x)
+    rphi_ratio1 = sign(thetaInteger)*_rphi_frequencyRatio(a, p1, 1, x)
+    
+    return sorted([rInteger/rphi_ratio0, rInteger/rphi_ratio1])
+
+def _tripleResonance_pe(a, x, rInteger, thetaInteger, phiInteger):
+    """Find (p, x) from resonant modes
+
+    Parameters
+    ----------
+    rMode : double
+        radial mode
+    thetaMode : double
+        polar-angle mode
+    phiMode : double
+        azimuthal-angle mode
+    a : double
+        dimensionless spin of the black hole
+    x : double
+        cosine of orbital inclination
+    
+    Returns
+    ------- 
+    (p, e) : (double, double)
+        Return orbital semi-latus rectum and orbital eccentricity, respectively
+    """
+    
+    a = abs(a)
+    xSign = sign(thetaInteger)
+    
+    if not valid_integers(rInteger, thetaInteger, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger|, thetaInteger*phiInteger>0 and thetaInteger<phiInteger")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if not valid_params(a, 0.5, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")  
+
+    p0_rtheta = _rtheta_resonance_p(a, 0, x, rInteger, thetaInteger)
+    p1_rtheta = _rtheta_resonance_p(a, 1, x, rInteger, thetaInteger)
+    p0_rphi = _rphi_resonance_p(a, 0, x, rInteger, phiInteger)
+    p1_rphi = _rphi_resonance_p(a, 1, x, rInteger, phiInteger)
+                                   
+    check_if_having_solution = (p0_rtheta-p0_rphi)*(p1_rtheta-p1_rphi)
+    
+    if (check_if_having_solution > 0) | (check_if_having_solution == nan):
+        rs = _tripleResonance_pe_rInteger(thetaInteger, phiInteger, a, x)
+        thetas = _tripleResonance_pe_thetaInteger(rInteger, phiInteger, a, x)
+        phis = _tripleResonance_pe_phiInteger(rInteger, thetaInteger, a, x)
+        print("No triple resonance, try changing one of the integers:")
+        print(f"Choose r-integer in {rs}")
+        print(f"Choose theta-integer in {thetas}")
+        print(f"Choose phi-integer in {phis}")
+        return [nan, nan]
+    elif check_if_having_solution < 0:
+        e0 = 1/((p1_rphi-p1_rtheta)/(p0_rtheta-p0_rphi)+1)
+        p0 = p0_rtheta-e0*(p0_rtheta-p1_rtheta)
+        sol = fsolve(lambda X: [_rtheta_frequencyRatio(a, X[0], X[1], x)*abs(thetaInteger)-rInteger,
+                                _rphi_frequencyRatio(a, X[0], X[1], x)*abs(phiInteger)-rInteger], [p0, e0])
+        return sol
+    else:
+        if (p0_rtheta-p0_rphi) == 0:
+            return [p0_rtheta, 0]
+        elif (p1_rtheta-p1_rphi) == 0:
+            return [p1_rtheta, 1]
+
+
+# Generic function
 def findResonance(a, p=None, e=None, x=None, integers=[0,0,0]):
     rInteger, thetaInteger, phiInteger = integers
     if (rInteger!=0) & (thetaInteger!=0) & (phiInteger!=0):
-        if e != None:
-            return _tripleResonance(a, e, rInteger, thetaInteger, phiInteger)
+        if (p==None) & (e!=None) & (x==None):
+            return _tripleResonance_px(a, e, rInteger, thetaInteger, phiInteger)
+        elif (p==None) & (e==None) & (x!=None):
+            return _tripleResonance_pe(a, x, rInteger, thetaInteger, phiInteger)
         else: 
-            raise ValueError("Only support finding (p,x) with given (a,e)")
+            raise ValueError("Only support finding triple resonances with given (a,x) or (a,e)")
         
     elif (rInteger==0) & (thetaInteger!=0) & (phiInteger!=0):
         if (p==None) & (e!=None) & (x!=None):

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -300,7 +300,12 @@ def phitheta_resonance(ratio, a, e, x):
     """
     
     a, x = _standardize_params(a, x)
-    
+    if ratio <= 0:
+        raise ValueError("The ratio must be positive")
+    if (ratio > 1) & (x < 0):
+        raise ValueError("The ratio must be larger than 1 if the orbit is prograde")
+    if (ratio < 1) & (x > 0):
+        raise ValueError("The ratio must be lesser than 1 if the orbit is retrograde")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     if x == 0:
@@ -386,16 +391,16 @@ def rphi_resonance_weakFieldLimit(ratio, a, p, e, is_prograde=True):
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
     
-    p0 = 6/(1-ratio**2)
     k_rtheta = lambda x: (2*(-6+p)*p+24*a*sqrt(p)*x
                           +3*a**2*(1-5*x**2+e**2*(-1+x**2))
                           )/(
                               2*p**2+3*e**2*(1+a**2*(-1+x**2)))
-    Lz_sign = (int(is_prograde)+1)/2
-    equation = lambda x: 1/abs(Lz_sign/sqrt(k_rtheta(x))+2*a/p**(3/2)+(-a**2*x-5*e**2*a**2*x/4)/p**2)-ratio
+    Lz_sign = 2*int(is_prograde)-1
+    equation = lambda x: abs(Lz_sign/sqrt(k_rtheta(x))*(1+a**2*(1-e**2)*(1-abs(x))/2/p**2)
+                             +2*a/p**(3/2)+(-a**2*x-5*e**2*a**2*x/4)/p**2)-1/ratio
     x_sol = newton(equation, x0=0.5*Lz_sign)
     return 1-x_sol**2
-    
+
 # Frequency ratio of r-theta and r-phi in special limits (support finding triple resonance)
 ## In the polar limit
 def rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde=True):

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -310,7 +310,6 @@ def phitheta_resonance(ratio, a, e, x):
     if not valid_params(a, e, x):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
-    k = ratio**2
     p0 = separatrix(a, e, x)+1e-10
     p_sol = newton(lambda p: abs(_phitheta_frequencyRatio(a, p, e, x))-ratio, x0=p0)
     return p_sol

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -208,16 +208,16 @@ def _doubleResonance_solver(equation, p0, sep):
     -------
     p : double
         orbital semi-latus rectum
-    '''
+    '''    
     try:
         p_sol = newton(equation, p0)
-    except RuntimeError:
+    except (RuntimeError, ValueError, RuntimeWarning):
         try:
             p_sol = root_scalar(equation, method="brentq", bracket=(sep+1e-5, p0)).root
         except:
             try:
                 p_sol = newton(equation, sep+1e-5)
-            except RuntimeError:
+            except (RuntimeError, ValueError, RuntimeWarning):
                 pass
             else:
                 return p_sol

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -331,8 +331,8 @@ def rtheta_resonance_weakFieldLimit(ratio, a, p, e):
 
     Returns
     -------
-    p : double
-        orbital semi-latus rectum
+    z_minus : double
+        squared cosine of the polar angle
     """
     a = abs(a)
     
@@ -354,7 +354,7 @@ def rtheta_resonance_weakFieldLimit(ratio, a, p, e):
             - (4 * p**2 * (1 - 6 * e**2 / p0)) / (5 - 6 * e**2 / p0)**4
         ))
 
-def rphi_resonance_weakFieldLimit(ratio, a, p, e):
+def rphi_resonance_weakFieldLimit(ratio, a, p, e, is_prograde=True):
     """Return approximated p of r-phi resonant orbit in the weak-field limit
 
     Parameters
@@ -365,36 +365,36 @@ def rphi_resonance_weakFieldLimit(ratio, a, p, e):
         dimensionless spin of the black hole
     e : double
         orbital eccentricity
-    x : double
-        cosine of the orbital inclination
+    p : double
+        orbital semi-latus rectum
 
     Returns
     -------
-    p : double
-        orbital semi-latus rectum
+    
+    z_minus : double
+        squared cosine of the polar angle
     """
     
-    a, x = _standardize_params(a, x)
+    a = abs(a)
     
     if not valid_frequencyRatio(ratio):
         raise ValueError("The ratio must be between 0 and 1")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
-    if x == 0:
-        raise ValueError("Polar orbits not supported")
     if e == 1:
         raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, x):
+    if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
     
     p0 = 6/(1-ratio**2)
-    k_rtheta = lambda p: abs((2*(-6+p)*p+24*a*sqrt(p)*x
+    k_rtheta = lambda x: (2*(-6+p)*p+24*a*sqrt(p)*x
                           +3*a**2*(1-5*x**2+e**2*(-1+x**2))
                           )/(
-                              2*p**2+3*e**2*(1+a**2*(-1+x**2))))
-    equation = lambda p: 1/abs(sign(x)/sqrt(k_rtheta(p))+2*a/p**(3/2)+(-a**2*x-5*e**2*a**2*x/4)/p**2)-ratio
-    p_sol = newton(equation, x0=p0)
-    return p_sol
+                              2*p**2+3*e**2*(1+a**2*(-1+x**2)))
+    Lz_sign = (int(is_prograde)+1)/2
+    equation = lambda x: 1/abs(Lz_sign/sqrt(k_rtheta(x))+2*a/p**(3/2)+(-a**2*x-5*e**2*a**2*x/4)/p**2)-ratio
+    x_sol = newton(equation, x0=0.5*Lz_sign)
+    return 1-x_sol**2
     
 # Frequency ratio of r-theta and r-phi in special limits (support finding triple resonance)
 ## In the polar limit

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -193,7 +193,7 @@ def _phitheta_frequencyRatio(a, p, e, x):
 ## In general 
 
 def _doubleResonance_solver(equation, p0, sep):
-    '''Try `scipy.newton` twive with different initial guess, one of them is very near the separatrix
+    '''Try `scipy.newton` with two different initial guess, one of them is very near the separatrix. Also try solving by using `scipy.root_scalar(method="brentq")`
     
     Parameters
     ----------
@@ -361,6 +361,15 @@ def rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde=True):
     -------
     double
     """
+    
+    a = abs(a)
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, 0.5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    
     Lz_sign = -1+2*int(is_prograde)
     P = (a**2*(a**4*(-1+e**2)*2+p**4+2*a**2*p*(-2+p+e**2*(2+p)))
          )/(
@@ -452,6 +461,14 @@ def phitheta_frequencyRatio_polarLimit(a, p, e, is_prograde=True):
     -------
     double
     """
+    a = abs(a)
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, 0.5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    
     Lz_sign = -1+2*int(is_prograde)
     P = (a**2*(a**4*(-1+e**2)*2+p**4+2*a**2*p*(-2+p+e**2*(2+p)))
          )/(
@@ -506,6 +523,13 @@ def rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
     -------
     double
     """
+    a = abs(a)
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, 0.5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
     
     Lz_sign = -1+2*int(is_prograde)
     P = 0
@@ -547,6 +571,14 @@ def rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
     -------
     double
     """
+    a = abs(a)
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, 0.5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    
     Lz_sign = -1+2*int(is_prograde)
     P = 0
     S = 2*(a**4*(-1+e**2)*p+(-4+p)*p**3+a**2*p**2*(3+e**2+p)
@@ -599,6 +631,14 @@ def phitheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
     -------
     double
     """
+    a = abs(a)
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, 0.5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    
     Lz_sign = -1+2*int(is_prograde)
     P = 0
     S = 2*(a**4*(-1+e**2)*p+(-4+p)*p**3+a**2*p**2*(3+e**2+p)

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -5,15 +5,185 @@ from .frequencies import _ellippi
 from .constants import *
 from .constants import _standardize_params
 from scipy.optimize import fsolve, newton, root_scalar
-from scipy.special import elliprf
+from scipy.special import elliprf, ellipk
 from numpy import sqrt, pi, sign
 
 def valid_frequencyRatio(ratio):
-    if (0 < ratio) & (ratio < 1):
+    if (0 < abs(ratio)) & (abs(ratio) < 1):
         return True
     else:
         return False
 
+def valid_integers(r, phi, theta):
+    if r < 0:
+        return False
+    if (r!=0) & (phi!=0) & (theta!=0):
+        if (r<abs(phi)) & (r<abs(theta)):
+            return True
+    elif (r==0) & (phi!=0) & (theta!=0):
+        if phi*theta>0:
+            return True
+    elif (r!=0) & (phi==0) & (theta!=0):
+        if r<abs(theta):
+            return True
+    elif (r!=0) & (phi!=0) & (theta==0):
+        if r<abs(phi):
+            return True
+    else:
+        return False
+
+# Frequency ratio functions
+## Needed functions
+def _r3r4_prod(a, p, e, x):
+    """
+    r3*r4
+    """
+    numerator_term1 = ((-4 + p) * p**7 + a**8 * (-1 + e**2)**4 * (-1 + x**2)**2 + 
+         2 * a**6 * (-1 + e**2)**2 * p * (1 - x**2) * ((1 + e**2) * p + (-2 + p + e**2 * (2 + p)) * (1 - x**2)) + 
+         a**4 * p**3 * ((-3 + 2 * e**2 + e**4) * p + 4 * (-4 + 3 * p + e**4 * (4 + p)) * (1 - x**2) + 
+         (-1 + e**2) * (-4 + e**2 * (-12 + p) + 3 * p) * (-1 + x**2)**2))
+    numerator_term2 =  ((-1 - e**2) * p**4 * (-2 + x**2) + 
+          8 * (-1 + e**2) * p**2 * (-1 + x**2) + 
+          2 * p**3 * (-3 - e**2 + 4 * (1 + e**2) * x**2))
+    numerator_term3 = (-1/(a**2*p))*(
+        (a**4*(-1 + e**2)**2 + 
+        (-4*e**2 + (-2 + p)**2)*p**2 + 
+        2*a**2*p*(-2 + p + e**2*(2 + p)))*x**2*(-p**2 + a**2*(-1 + e)**2*(-1 + x**2))*
+        (-p**2 + a**2*(1 + e)**2*(-1 + x**2))*(-p**2 + a**2*(-1 + e**2)*(-1 + x**2)))
+    if x>=0:
+        numerator = a**2*(1-x**2)*(numerator_term1+2*a**2*p**2*(numerator_term2-4*sqrt(numerator_term3)))
+    else:
+        numerator = a**2*(1-x**2)*(numerator_term1+2*a**2*p**2*(numerator_term2+4*sqrt(numerator_term3)))
+    denominator = ((-4 + p)**2 * p**6 + a**8 * (-1 + e**2)**4 * (-1 + x**2)**2 + 
+         2 * a**2 * p**5 * ((-1 + e**2) * (4 + p) + (-4 + e**2 * (-12 + p) + 3 * p) * (1 - x**2)) + 
+         2 * a**6 * (-1 + e**2)**2 * p**2 * (-1 + x**2) * (-2 + 3 * x**2 + e**2 * (-2 + x**2)) + 
+         a**4 * p**3 * (-8 * (-1 + e**2)**2 * (1 - 3 * x**2 + 2 * x**4) + 
+         p * ((-1 + e**2)**2 - 4 * (-1 + e**4) * (-1 + x**2) + (3 + e**2)**2 * (-1 + x**2)**2)))
+
+    return numerator/denominator
+
+def _r3r4_prod_reduced(a, p, e, x):
+    """
+    r3*r4/(1-x^2)
+    """
+    numerator_term1 = ((-4 + p) * p**7 + a**8 * (-1 + e**2)**4 * (-1 + x**2)**2 + 
+         2 * a**6 * (-1 + e**2)**2 * p * (1 - x**2) * ((1 + e**2) * p + (-2 + p + e**2 * (2 + p)) * (1 - x**2)) + 
+         a**4 * p**3 * ((-3 + 2 * e**2 + e**4) * p + 4 * (-4 + 3 * p + e**4 * (4 + p)) * (1 - x**2) + 
+         (-1 + e**2) * (-4 + e**2 * (-12 + p) + 3 * p) * (-1 + x**2)**2))
+    numerator_term2 =  ((-1 - e**2) * p**4 * (-2 + x**2) + 
+          8 * (-1 + e**2) * p**2 * (-1 + x**2) + 
+          2 * p**3 * (-3 - e**2 + 4 * (1 + e**2) * x**2))
+    numerator_term3 = (-1/(a**2*p))*(
+        (a**4*(-1 + e**2)**2 + 
+        (-4*e**2 + (-2 + p)**2)*p**2 + 
+        2*a**2*p*(-2 + p + e**2*(2 + p)))*x**2*(-p**2 + a**2*(-1 + e)**2*(-1 + x**2))*
+        (-p**2 + a**2*(1 + e)**2*(-1 + x**2))*(-p**2 + a**2*(-1 + e**2)*(-1 + x**2)))
+    if x>=0:
+        numerator = a**2*(numerator_term1+2*a**2*p**2*(numerator_term2-4*sqrt(numerator_term3)))
+    else:
+        numerator = a**2*(numerator_term1+2*a**2*p**2*(numerator_term2+4*sqrt(numerator_term3)))
+    denominator = ((-4 + p)**2 * p**6 + a**8 * (-1 + e**2)**4 * (-1 + x**2)**2 + 
+         2 * a**2 * p**5 * ((-1 + e**2) * (4 + p) + (-4 + e**2 * (-12 + p) + 3 * p) * (1 - x**2)) + 
+         2 * a**6 * (-1 + e**2)**2 * p**2 * (-1 + x**2) * (-2 + 3 * x**2 + e**2 * (-2 + x**2)) + 
+         a**4 * p**3 * (-8 * (-1 + e**2)**2 * (1 - 3 * x**2 + 2 * x**4) + 
+         p * ((-1 + e**2)**2 - 4 * (-1 + e**4) * (-1 + x**2) + (3 + e**2)**2 * (-1 + x**2)**2)))
+    return numerator/denominator
+
+def _r3r4_sum(a, p, e, x):
+    if a != 0:
+        return (-p**2+a**2*(1-e**2)*(1-x**2))*(a**2-_r3r4_prod_reduced(a,p,e,x))/(2*a**2*p)
+    else:
+        return 2*p/(p-4)
+
+def _r3(a, p, e, x):
+    delta = _r3r4_sum(a,p,e,x)**2-4*_r3r4_prod(a,p,e,x)
+    return (_r3r4_sum(a,p,e,x)+sqrt(delta))/2
+
+def _r4(a, p, e, x):
+    delta = _r3r4_sum(a,p,e,x)**2-4*_r3r4_prod(a,p,e,x)
+    return (_r3r4_sum(a,p,e,x)-sqrt(delta))/2
+
+def _E2(a, p, e, x):
+    """
+    Squared energy
+    """
+    return 1-2*(1-e**2)/(2*p+(1-e**2)*_r3r4_sum(a,p,e,x))
+
+def _L2(a, p, e, x):
+    """
+    Squared angular momentum
+    """
+    numerator = 2*(a**2*(-1+e**2)+p**2)*(a**2-_r3r4_prod(a,p,e,x))+4*a**2*p*_r3r4_sum(a,p,e,x)
+    denominator = a**2*(2*p+(1-e**2)*_r3r4_sum(a,p,e,x))
+    return numerator/denominator
+
+def _del1y1(a, p, e, x):
+    numerator = -e*p*sqrt(_r3r4_sum(a,p,e,x)**2-4*_r3r4_prod(a,p,e,x))
+    denominator = (1-e**2)*_r3r4_prod(a,p,e,x)+p**2-p*_r3r4_sum(a,p,e,x)
+    return numerator/denominator
+
+def _del2y2(a, p, e, x):
+    numerator = (1-e**2)*a**4*(1-x**2)
+    denominator = (1-e**2)*a**4*(1-x**2)-2*p**2*_r3r4_prod_reduced(a,p,e,x)
+    return numerator/denominator
+
+def _y1y2(a, p, e, x):
+    numerator = 2*a**2*((1-e**2)*_r3r4_prod(a,p,e,x)+p**2-p*_r3r4_sum(a,p,e,x))
+    denominator = a**4*(e**2-1)*(1-x**2)+2*p**2*_r3r4_prod_reduced(a,p,e,x)
+    return numerator/denominator
+
+def _kr(a,p,e,x):
+    numerator = (p-p*(1-e)/(1+e))*(_r3(a,p,e,x)-_r4(a,p,e,x))
+    denominator = (p-_r3(a,p,e,x)*(1-e))*(p/(1+e)-_r4(a,p,e,x))
+    return numerator/denominator
+
+def _ktheta(a,p,e,x):
+    return (1-x**2)*(1-e**2)*a**4/(p**2*_r3r4_prod_reduced(a,p,e,x))
+
+def _rPlus(a):
+    return 1+sqrt(1-a**2)
+
+def _rMinus(a):
+    return 1-sqrt(1-a**2)
+
+def _hPlus(a,p,e,x):
+    numerator = (p-p*(1-e)/(1+e))*(_r3(a,p,e,x)-_rPlus(a))
+    denominator = (p-_r3(a,p,e,x)*(1-e))*(p/(1+e)-_rPlus(a))
+    return numerator/denominator
+
+def _hMinus(a,p,e,x):
+    numerator = (p-p*(1-e)/(1+e))*(_r3(a,p,e,x)-_rMinus(a))
+    denominator = (p-_r3(a,p,e,x)*(1-e))*(p/(1+e)-_rMinus(a))
+    return numerator/denominator
+
+def _phiTerm_thetaPrefactor(a,p,e,x):
+    numerator = (a**2*(-1+e**2)+p**2)*(a**2-_r3r4_prod(a,p,e,x))+2*a**2*p*_r3r4_sum(a,p,e,x)
+    denominator = p**2*_r3r4_prod_reduced(a,p,e,x)
+    return 2/pi*sqrt(numerator/denominator)
+
+def _phiTerm_rPrefactor(a,p,e,x):
+    term1 = 2*a/(pi*(_rPlus(a)-_rMinus(a)))
+    term2_numerator = 2*p+(1-e**2)*_r3r4_sum(a,p,e,x)
+    term2_denominator = 2*(p-_r3(a,p,e,x)*(1-e))*(p-_r4(a,p,e,x)*(1+e))
+    return term1*sqrt(term2_numerator/term2_denominator)
+
+def _phiTerm_rPrefactorPlus(a,p,e,x):
+    term1 = (2*sqrt(_E2(a,p,e,x))*_rPlus(a)-a*sign(x)*sqrt(abs(_L2(a,p,e,x))))/(_r3(a,p,e,x)-_rPlus(a))
+    term2 = ellipk(_kr(a,p,e,x))-(p/(1+e)-_r3(a,p,e,x))/(p/(1+e)-_rPlus(a))*_ellippi(_hPlus(a,p,e,x),_kr(a,p,e,x))
+    return term1*term2
+
+def _phiTerm_rPrefactorMinus(a,p,e,x):
+    term1 = (2*sqrt(_E2(a,p,e,x))*_rMinus(a)-a*sign(x)*sqrt(abs(_L2(a,p,e,x))))/(_r3(a,p,e,x)-_rMinus(a))
+    term2 = ellipk(_kr(a,p,e,x))-(p/(1+e)-_r3(a,p,e,x))/(p/(1+e)-_rMinus(a))*_ellippi(_hMinus(a,p,e,x),_kr(a,p,e,x))
+    return term1*term2
+
+def _phiTerm_thetaTerm(a,p,e,x):
+    return _phiTerm_thetaPrefactor(a,p,e,x)*_ellippi(1-x**2,_ktheta(a,p,e,x))
+
+def _phiTerm_rTerm(a,p,e,x):
+    return _phiTerm_rPrefactor(a,p,e,x)*(_phiTerm_rPrefactorPlus(a,p,e,x)-_phiTerm_rPrefactorMinus(a,p,e,x))
+
+## frequency ratios
 def _rtheta_frequencyRatio(a, p, e, x):
     """Ratio of r-frequency and theta-frequency  
 
@@ -36,25 +206,10 @@ def _rtheta_frequencyRatio(a, p, e, x):
     
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
-    
-    
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, x):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    if not is_stable(a, p, e, x):
+    if not is_stable(a,p,e,x):
         raise ValueError("Not a stable orbit")
+    return sqrt(_y1y2(a,p,e,x))*elliprf(0, 1+_del2y2(a,p,e,x), 1-_del2y2(a,p,e,x))/elliprf(0, 1+_del1y1(a,p,e,x), 1-_del1y1(a,p,e,x))
 
-    r1, r2, r3, r4 = stable_radial_roots(a, p, e, x)
-    z_minus, z_plus = stable_polar_roots(a, p, e, x)
-
-    y1 = (p**2-p*(r3+r4))/(1-e**2)+r3*r4
-    y2 = a**2/2*(2*z_plus-z_minus)
-    d1 = e*p*(r4-r3)/(1-e**2)
-    d2 = -a**2*z_minus/2
-
-    return sign(x)*sqrt(y1/y2)*elliprf(0, 1+d2/y2, 1-d2/y2)/elliprf(0, 1+d1/y1, 1-d1/y1)
-    
 def _rphi_frequencyRatio(a, p, e, x):
     """Ratio of r-frequency and phi-frequency 
 
@@ -77,50 +232,12 @@ def _rphi_frequencyRatio(a, p, e, x):
     
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
-    if x == 0:
-        raise ValueError("Polar orbits not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, x):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    if not is_stable(a, p, e, x):
+    if not is_stable(a,p,e,x):
         raise ValueError("Not a stable orbit")
-    
-    r1, r2, r3, r4 = stable_radial_roots(a, p, e, x)
-    z_minus, z_plus = stable_polar_roots(a, p, e, x)
-    E, L, Q = constants_of_motion(a, p, e, x)
-    
-    r_plus = 1 + sqrt(1 - a**2)
-    r_minus = 1 - sqrt(1 - a**2)
-
-    k_r = sqrt((r1 - r2) * (r3 - r4) / ((r1 - r3) * (r2 - r4)))
-    k_theta = sqrt(z_minus / z_plus)
-    h_plus = (r1 - r2) * (r3 - r_plus) / ((r1 - r3) * (r2 - r_plus))
-    h_minus = (r1 - r2) * (r3 - r_minus) / ((r1 - r3) * (r2 - r_minus))
-    
-    # simplified form of epsilon0*z_plus
-    e0zp = (a**2 * (1 - E**2) * (1 - z_minus) + L**2) / (L**2 * (1 - z_minus))
-    
-    #theta-r ratio
-    y1 = (p**2-p*(r3+r4))/(1-e**2)+r3*r4
-    y2 = a**2/2*(2*z_plus-z_minus)
-    d1 = e*p*(r4-r3)/(1-e**2)
-    d2 = -a**2*z_minus/2
-    thetar_ratio = sign(x)*sqrt(y2/y1)*elliprf(0, 1+d1/y1,1-d1/y1)/elliprf(0, 1+d2/y2, 1-d2/y2)
-    
-    #coefficients
-    Btheta = 2 / (pi * sqrt(e0zp)) * _ellippi(z_minus, k_theta**2)
-    Br = 2 * a / (
-        pi * (r_plus - r_minus) * sqrt((1 - E**2) * (r1 - r3) * (r2 - r4))
-    ) * (
-        (2 * E * r_plus - a * L)
-        / (r3 - r_plus)
-        * (ellipk(k_r**2) - (r2 - r3) / (r2 - r_plus) * _ellippi(h_plus, k_r**2))
-        - (2 * E * r_minus - a * L)
-        / (r3 - r_minus)
-        * (ellipk(k_r**2) - (r2 - r3) / (r2 - r_minus) * _ellippi(h_minus, k_r**2))
-    )
-    return 1/(Btheta*thetar_ratio+Br)
+    if x != 0: 
+        return sign(x)/(sign(x)*_phiTerm_thetaTerm(a,p,e,x)/_rtheta_frequencyRatio(a,p,e,x)+_phiTerm_rTerm(a,p,e,x))
+    else:
+        return [1/(1/_rtheta_frequencyRatio(a,p,e,x)+_phiTerm_rTerm(a,p,e,x)), -1/(-1/_rtheta_frequencyRatio(a,p,e,x)+_phiTerm_rTerm(a,p,e,x))]
 
 def _phitheta_frequencyRatio(a, p, e, x):
     """Ratio of r-frequency and phi-frequency 
@@ -144,50 +261,12 @@ def _phitheta_frequencyRatio(a, p, e, x):
     
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
-    if x == 0:
-        raise ValueError("Polar orbits not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, x):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    if not is_stable(a, p, e, x):
+    if not is_stable(a,p,e,x):
         raise ValueError("Not a stable orbit")
-    
-    r1, r2, r3, r4 = stable_radial_roots(a, p, e, x)
-    z_minus, z_plus = stable_polar_roots(a, p, e, x)
-    E, L, Q = constants_of_motion(a, p, e, x)
-    
-    r_plus = 1 + sqrt(1 - a**2)
-    r_minus = 1 - sqrt(1 - a**2)
-
-    k_r = sqrt((r1 - r2) * (r3 - r4) / ((r1 - r3) * (r2 - r4)))
-    k_theta = sqrt(z_minus / z_plus)
-    h_plus = (r1 - r2) * (r3 - r_plus) / ((r1 - r3) * (r2 - r_plus))
-    h_minus = (r1 - r2) * (r3 - r_minus) / ((r1 - r3) * (r2 - r_minus))
-    
-    #simplified form of epsilon0*z_plus
-    e0zp = (a**2 * (1 - E**2) * (1 - z_minus) + L**2) / (L**2 * (1 - z_minus))
-    
-    #theta-r ratio
-    y1 = (p**2-p*(r3+r4))/(1-e**2)+r3*r4
-    y2 = a**2/2*(2*z_plus-z_minus)
-    d1 = e*p*(r4-r3)/(1-e**2)
-    d2 = -a**2*z_minus/2
-    rtheta_ratio = sign(x)*sqrt(y1/y2)*elliprf(0, 1+d2/y2,1-d2/y2)/elliprf(0, 1+d1/y1, 1-d1/y1)
-    
-    #coefficients
-    Btheta = 2 / (pi * sqrt(e0zp)) * _ellippi(z_minus, k_theta**2)
-    Br = 2 * a / (
-        pi * (r_plus - r_minus) * sqrt((1 - E**2) * (r1 - r3) * (r2 - r4))
-    ) * (
-        (2 * E * r_plus - a * L)
-        / (r3 - r_plus)
-        * (ellipk(k_r**2) - (r2 - r3) / (r2 - r_plus) * _ellippi(h_plus, k_r**2))
-        - (2 * E * r_minus - a * L)
-        / (r3 - r_minus)
-        * (ellipk(k_r**2) - (r2 - r3) / (r2 - r_minus) * _ellippi(h_minus, k_r**2))
-    )
-    return Btheta+Br*rtheta_ratio
+    if x != 0: 
+        return _phiTerm_thetaTerm(a,p,e,x)+sign(x)*_rtheta_frequencyRatio(a,p,e,x)*_phiTerm_rTerm(a,p,e,x)
+    else:
+        return [1+_rtheta_frequencyRatio(a,p,e,x)*_phiTerm_rTerm(a,p,e,x),1-_rtheta_frequencyRatio(a,p,e,x)*_phiTerm_rTerm(a,p,e,x)]
 
 # Finding resonance
 ## In general 
@@ -209,25 +288,27 @@ def _doubleResonance_solver(equation, p0, sep):
     p : double
         orbital semi-latus rectum
     '''    
-    try:
-        p_sol = newton(equation, p0)
-    except (RuntimeError, ValueError, RuntimeWarning):
+    if p0 < sep:
         try:
-            p_sol = root_scalar(equation, method="brentq", bracket=(sep+1e-5, p0)).root
+            return newton(equation, sep+1e-5)
+        except (RuntimeError, ValueError):
+            pass
+    try:
+        return newton(equation, p0)
+    except (RuntimeError, ValueError):
+        try:
+            return root_scalar(equation, method="brentq", bracket=(sep+1e-5, p0)).root
         except:
             try:
-                p_sol = newton(equation, sep+1e-5)
-            except (RuntimeError, ValueError, RuntimeWarning):
+                return newton(equation, sep+1e-5)
+            except (RuntimeError, ValueError):
                 pass
-            else:
-                return p_sol
-        else:
-            return p_sol
-    else:
-        return p_sol
-    raise RuntimeError("p is too close to the separatrix")
-    
-def rtheta_resonance(ratio, a, e, x):
+    print("p is too close to the separatrix or no resonance. The result is set to sep+1e-5")
+    return sep+1e-5
+
+# find resonance
+## r-theta resonance
+def _rtheta_resonance_p(a, e, x, rInteger, thetaInteger):
     """Return p of r-theta resonant orbit
     
     Parameters
@@ -248,23 +329,104 @@ def rtheta_resonance(ratio, a, e, x):
     """
     
     a, x = _standardize_params(a, x)
-    
-    if not valid_frequencyRatio(ratio):
-        raise ValueError("The ratio must be between 0 and 1")
+    if not valid_integers(rInteger, thetaInteger, 0):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
     if a == 1:
-        raise ValueError("Extreme Kerr not supported")
-    if x == 0:
-        raise ValueError("Polar orbits not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, x):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-
-    return _doubleResonance_solver(lambda p: abs(_rtheta_frequencyRatio(a, p, e, x))-ratio,
+        raise ValueError("Extreme Kerr not supported") 
+    ratio = rInteger/thetaInteger
+    if sign(x)*sign(ratio)<0:
+            raise ValueError("Require sign(x) = sign(rInteger/thetaInteger)")
+    return _doubleResonance_solver(lambda p: _rtheta_frequencyRatio(a, p, e, x)-abs(ratio),
                                    6/(1-ratio**2),
                                    separatrix(a, e, x))
 
-def rphi_resonance(ratio, a, e, x):
+def _rtheta_resonance_e(a, p, x, rInteger, thetaInteger):
+    """Return p of r-theta resonant orbit
+    
+    Parameters
+    ----------
+    ratio: double
+        r-theta frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    """
+    
+    a, x = _standardize_params(a, x)
+    if not valid_integers(rInteger, thetaInteger, 0):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported") 
+    ratio = rInteger/thetaInteger
+    if sign(x)*sign(ratio)<0:
+            raise ValueError("Require sign(x) = sign(rInteger/thetaInteger)")
+    p0 = _rtheta_resonance_p(a, 0, x, rInteger, thetaInteger)
+    p1 = _rtheta_resonance_p(a, 1, x, rInteger, thetaInteger)
+    if (p<p0)|(p1<p):
+        print(f"p must be in [{p0:f},{p1:f}]")
+        return nan
+    if p == p0:
+        return 0
+    elif p == p1:
+        return 1
+    else:
+        e0 = (p-p0)/(p1-p0)
+        return newton(lambda e: _rtheta_frequencyRatio(a, p, e, x)-abs(ratio), e0)
+
+def _rtheta_resonance_x(a, p, e, rInteger, thetaInteger):
+    """Return p of r-theta resonant orbit
+    
+    Parameters
+    ----------
+    ratio: double
+        r-theta frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    """
+    
+    a = abs(a)
+    if not valid_integers(rInteger, thetaInteger, 0):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported") 
+    ratio = rInteger/thetaInteger
+    Lz_sign = sign(ratio)
+    p0 = _rtheta_resonance_p(a, e, 0, rInteger, thetaInteger)
+    p1 = _rtheta_resonance_p(a, e, Lz_sign, rInteger, thetaInteger)
+    if (ratio>0)&((p<p1)|(p0<p)):
+        print(f"p must be in [{p1:f},{p0:f}]")
+        return nan
+    if (ratio<0)&((p<p0)|(p1<p)):
+        print(f"p must be in [{p0:f},{p1:f}]")
+        return nan
+    if p == p0:
+        return 0
+    elif p == p1:
+        return 1
+    else:
+        x0 = Lz_sign*(p-p0)/(p1-p0)
+        return newton(lambda x: _rtheta_frequencyRatio(a, p, e, x)-abs(ratio), x0)
+
+## r-phi resonance
+
+def _rphi_resonance_p(a, e, x, rInteger, phiInteger):
     """Return p of r-phi resonant orbit
 
     Parameters
@@ -285,23 +447,117 @@ def rphi_resonance(ratio, a, e, x):
     """
     
     a, x = _standardize_params(a, x)
-    
-    if not valid_frequencyRatio(ratio):
-        raise ValueError("The ratio must be between 0 and 1")
+    if not valid_integers(rInteger, 0, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
+    ratio = rInteger/phiInteger
     if x == 0:
-        raise ValueError("Polar orbits not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, x):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+        if ratio > 0:
+            resonantEquation = lambda p: _rphi_frequencyRatio(a, p, e, 0)[0]-abs(ratio)
+        elif ratio < 0:
+            resonantEquation = lambda p: _rphi_frequencyRatio(a, p, e, 0)[1]-abs(ratio)
+    else:
+        if sign(x)*sign(ratio)<0:
+            raise ValueError("Require sign(x) = sign(rInteger/phiInteger)")
+        resonantEquation = lambda p: _rphi_frequencyRatio(a, p, e, x)-abs(ratio)
+    p0 = 6/(1-ratio**2)
+    pSep = separatrix(a, e, x)
+    return _doubleResonance_solver(resonantEquation, p0, pSep)
 
-    return _doubleResonance_solver(lambda p: abs(_rphi_frequencyRatio(a, p, e, x))-ratio,
-                                   6/(1-ratio**2),
-                                   separatrix(a, e, x))
+def _rphi_resonance_e(a, p, x, rInteger, phiInteger):
+    """Return p of r-phi resonant orbit
 
-def phitheta_resonance(ratio, a, e, x):
+    Parameters
+    ----------
+    ratio: double
+        r-phi frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    """
+    
+    a, x = _standardize_params(a, x)
+    if not valid_integers(rInteger, 0, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    ratio = rInteger/phiInteger
+    p0 = _rphi_resonance_p(a, 0, x, rInteger, phiInteger)
+    p1 = _rphi_resonance_p(a, 1, x, rInteger, phiInteger)
+    if (p<p0)|(p1<p):
+        print(f"p must be in [{p0:f},{p1:f}]")
+        return nan
+    if p == p0:
+        return 0
+    if p == p1:
+        return 1
+    e0 = (p-p0)/(p1-p0)
+    if x == 0:
+        if ratio > 0:
+            resonantEquation = lambda e: _rphi_frequencyRatio(a, p, e, x)[0]-abs(ratio)
+        elif ratio < 0:
+            resonantEquation = lambda e: _rphi_frequencyRatio(a, p, e, x)[1]-abs(ratio)
+    else:
+        if sign(x)*sign(ratio)<0:
+            raise ValueError("Require sign(x) = sign(rInteger/phiInteger)")
+        resonantEquation = lambda e: _rphi_frequencyRatio(a, p, e, x)-abs(ratio)
+    return newton(resonantEquation, e0)
+
+def _rphi_resonance_x(a, p, e, rInteger, phiInteger):
+    """Return p of r-phi resonant orbit
+
+    Parameters
+    ----------
+    ratio: double
+        r-phi frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    """
+    
+    a = abs(a)
+    if not valid_integers(rInteger, 0, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    ratio = rInteger/phiInteger
+    Lz_sign = sign(ratio)
+    p0 = _rphi_resonance_p(a, e, 0, rInteger, phiInteger)
+    p1 = _rphi_resonance_p(a, e, Lz_sign, rInteger, phiInteger)
+    if (ratio>0)&((p<p1)|(p0<p)):
+        print(f"p must be in [{p1:f},{p0:f}]")
+        return nan
+    if (ratio<0)&((p<p0)|(p1<p)):
+        print(f"p must be in [{p0:f},{p1:f}]")
+        return nan
+    if p == p0:
+        return 0
+    if p == p1:
+        return 1
+    x0 = Lz_sign*(p-p0)/(p1-p0)
+    resonantEquation = lambda x: _rphi_frequencyRatio(a, p, e, x)-abs(ratio)
+    return newton(resonantEquation, x0)
+
+## phi-theta resonance
+
+def _phitheta_resonance_p(a, e, x, thetaInteger, phiInteger):
     """Return p of phi-theta resonant orbit
 
     Parameters
@@ -322,360 +578,120 @@ def phitheta_resonance(ratio, a, e, x):
     """
     
     a, x = _standardize_params(a, x)
-    if (ratio <= 0) | (ratio == 1):
-        raise ValueError("The ratio must be positive and not equal to 1")
-    if (ratio > 1) & (x < 0):
-        raise ValueError("The ratio must be larger than 1 if the orbit is prograde")
-    if (ratio < 1) & (x > 0):
-        raise ValueError("The ratio must be lesser than 1 if the orbit is retrograde")
+    if not valid_integers(0, thetaInteger, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
-    if x == 0:
-        raise ValueError("Polar orbits not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
     if not valid_params(a, e, x):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    ratio = phiInteger/thetaInteger
+    if x == 0:
+        if ratio > 1:
+            resonantEquation = lambda p: _phitheta_frequencyRatio(a, p, e, 0)[0]-ratio
+        elif ratio < 1:
+            resonantEquation = lambda p: _phitheta_frequencyRatio(a, p, e, 0)[1]-ratio
+    else:
+        if sign(x)*sign(ratio-1)<0:
+            raise ValueError("Require sign(x) = sign(phiInteger/thetaInteger-1)")
+        resonantEquation = lambda p: _phitheta_frequencyRatio(a, p, e, x)-ratio
+    p0 = (2*a/abs(ratio-1))**(2/3)
+    pSep = separatrix(a, e, x)
+    return _doubleResonance_solver(resonantEquation, p0, pSep)
 
-    return _doubleResonance_solver(lambda p: abs(_phitheta_frequencyRatio(a, p, e, x))-ratio,
-                                   (2*a/abs(ratio-1))**(2/3),
-                                   separatrix(a, e, x))
+def _phitheta_resonance_e(a, p, x, thetaInteger, phiInteger):
+    """Return p of r-phi resonant orbit
 
-# Frequency ratio of r-theta and r-phi in special limits (support finding triple resonance)
-## In the polar limit
-def rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde=True):
-    """Ratio of r-frequency and theta-frequency in the polar limit
-    
     Parameters
     ----------
+    ratio: double
+        r-phi frequency ratio
     a : double
         dimensionless spin of the black hole
-    p : double
-        orbital semi-latus rectum
     e : double
         orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+    x : double
+        cosine of the orbital inclination
 
     Returns
     -------
-    double
+    p : double
+        orbital semi-latus rectum
+    """
+    
+    a, x = _standardize_params(a, x)
+    if not valid_integers(0, thetaInteger, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    ratio = phiInteger/thetaInteger
+    p0 = _phitheta_resonance_p(a, 0, x, thetaInteger, phiInteger)
+    p1 = _phitheta_resonance_p(a, 1, x, thetaInteger, phiInteger)
+    if (p<p0)|(p1<p):
+        print(f"p must be in [{p0:f},{p1:f}]")
+        return nan
+    if p == p0:
+        return 0
+    if p == p1:
+        return 1
+    e0 = (p-p0)/(p1-p0)
+    if x == 0:
+        if ratio > 1:
+            resonantEquation = lambda e: _phitheta_frequencyRatio(a, p, e, x)[0]-abs(ratio)
+        elif ratio < 1:
+            resonantEquation = lambda e: _phitheta_frequencyRatio(a, p, e, x)[1]-abs(ratio)
+    else:
+        if sign(x)*sign(ratio-1)<0:
+            raise ValueError("Require sign(x) = sign(phiInteger/thetaInteger-1)")
+        resonantEquation = lambda e: _phitheta_frequencyRatio(a, p, e, x)-abs(ratio)
+    return newton(resonantEquation, e0)
+
+def _phitheta_resonance_x(a, p, e, thetaInteger, phiInteger):
+    """Return p of r-phi resonant orbit
+
+    Parameters
+    ----------
+    ratio: double
+        r-phi frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
     """
     
     a = abs(a)
+    
+    if not valid_integers(0, thetaInteger, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, 0.5):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    
-    Lz_sign = -1+2*int(is_prograde)
-    P = (a**2*(a**4*(-1+e**2)*2+p**4+2*a**2*p*(-2+p+e**2*(2+p)))
-         )/(
-             a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
-    S = (2*(a**2*(-1+e**2)+p**2)**2
-         )/(
-            a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
-    r1 = p/(1-e)
-    r2 = p/(1+e)
-    r3 = (S+sqrt(S**2-4*P))/2
-    r4 = (S-sqrt(S**2-4*P))/2
-    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
-    Q = 2*p**2*P/(a**2*(2*p+S-e**2*S))
-    #L2 = 0
-    #z2 = 1
-    #z1 = Q/(1-E2)/a**2/z2
-    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
-    k_theta = (1-E2)*a**2/Q
-    factor = Lz_sign*sqrt((r1-r3)*(r2-r4)*2*(1-e**2)*a**2/(2*p**2*P))
-    return factor*ellipk(k_theta)/ellipk(k_r)
-
-def rphi_frequencyRatio_polarLimit(a, p, e, is_prograde=True):
-    """Ratio of r-frequency and phi-frequency in the polar limit
-    
-    Parameters
-    ----------
-    a : double
-        dimensionless spin of the black hole
-    p : double
-        orbital semi-latus rectum
-    e : double
-        orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
-
-    Returns
-    -------
-    double
-    """
-    Lz_sign = -1+2*int(is_prograde)
-    P = (a**2*(a**4*(-1+e**2)*2+p**4+2*a**2*p*(-2+p+e**2*(2+p)))
-         )/(
-             a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
-    S = (2*(a**2*(-1+e**2)+p**2)**2
-         )/(
-            a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
-    r1 = p/(1-e)
-    r2 = p/(1+e)
-    r3 = (S+sqrt(S**2-4*P))/2
-    r4 = (S-sqrt(S**2-4*P))/2
-    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
-    Q = 2*p**2*P/(a**2*(2*p+S-e**2*S))
-    #L2 = 0
-    #z2 = 1
-    #z1 = Q/(1-E2)/a**2/z2
-    
-    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
-    k_theta = (1-E2)*a**2/Q
-    factor1 = Lz_sign*sqrt((r1-r3)*(r2-r4)*2*(1-e**2)*a**2/(2*p**2*P))
-    rtheta_ratio = factor1*ellipk(k_theta)/ellipk(k_r)
-    
-    r_plus = 1+sqrt(1-a**2)
-    r_minus = 1-sqrt(1-a**2)
-    h_r = (r1-r2)/(r1-r3)
-    h_plus = h_r*(r3-r_plus)/(r2-r_plus)
-    h_minus = h_r*(r3-r_minus)/(r2-r_minus)
-    factor2 = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E2)*(r1-r3)*(r2-r4)))*2*sqrt(E2)
-    B_r_plus = r_plus/(r3-r_plus)*(ellipk(k_r)-(r2-r3)/(r2-r_plus)*_ellippi(h_plus, k_r))
-    B_r_minus = r_minus/(r3-r_minus)*(ellipk(k_r)-(r2-r3)/(r2-r_minus)*_ellippi(h_minus, k_r))
-    B_r = factor2*(B_r_plus-B_r_minus)
-    #B_theta = 1
-    return 1/(B_r+1/rtheta_ratio)
-
-def phitheta_frequencyRatio_polarLimit(a, p, e, is_prograde=True):
-    """Ratio of phi-frequency and theta-frequency in the polar limit
-    
-    Parameters
-    ----------
-    a : double
-        dimensionless spin of the black hole
-    p : double
-        orbital semi-latus rectum
-    e : double
-        orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
-
-    Returns
-    -------
-    double
-    """
-    a = abs(a)
-    if a == 1:
-        raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, 0.5):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    
-    Lz_sign = -1+2*int(is_prograde)
-    P = (a**2*(a**4*(-1+e**2)*2+p**4+2*a**2*p*(-2+p+e**2*(2+p)))
-         )/(
-             a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
-    S = (2*(a**2*(-1+e**2)+p**2)**2
-         )/(
-            a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
-    r1 = p/(1-e)
-    r2 = p/(1+e)
-    r3 = (S+sqrt(S**2-4*P))/2
-    r4 = (S-sqrt(S**2-4*P))/2
-    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
-    Q = 2*p**2*P/(a**2*(2*p+S-e**2*S))
-    #L2 = 0
-    #z2 = 1
-    #z1 = Q/(1-E2)/a**2/z2
-    
-    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
-    k_theta = (1-E2)*a**2/Q
-    factor1 = Lz_sign*sqrt((r1-r3)*(r2-r4)*2*(1-e**2)*a**2/(2*p**2*P))
-    rtheta_ratio = factor1*ellipk(k_theta)/ellipk(k_r)
-    
-    r_plus = 1+sqrt(1-a**2)
-    r_minus = 1-sqrt(1-a**2)
-    h_r = (r1-r2)/(r1-r3)
-    h_plus = h_r*(r3-r_plus)/(r2-r_plus)
-    h_minus = h_r*(r3-r_minus)/(r2-r_minus)
-    factor2 = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E2)*(r1-r3)*(r2-r4)))*2*sqrt(E2)
-    B_r_plus = r_plus/(r3-r_plus)*(ellipk(k_r)-(r2-r3)/(r2-r_plus)*_ellippi(h_plus, k_r))
-    B_r_minus = r_minus/(r3-r_minus)*(ellipk(k_r)-(r2-r3)/(r2-r_minus)*_ellippi(h_minus, k_r))
-    B_r = factor2*(B_r_plus-B_r_minus)
-    #B_theta = 1
-    return B_r*rtheta_ratio+1
-
-
-## In the equatorial limit
-def rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
-    """Ratio of r-frequency and theta-frequency in the equatorial limit
-    
-    Parameters
-    ----------
-    a : double
-        dimensionless spin of the black hole
-    p : double
-        orbital semi-latus rectum
-    e : double
-        orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
-
-    Returns
-    -------
-    double
-    """
-    a = abs(a)
-    if a == 1:
-        raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, 0.5):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    
-    Lz_sign = -1+2*int(is_prograde)
-    P = 0
-    S = 2*(a**4*(-1+e**2)*p+(-4+p)*p**3+a**2*p**2*(3+e**2+p)
-           -Lz_sign*2*sqrt(a**2*p**3*(a**4*(-1+e**2)**2+(-4*e**2+(-2+p)**2)*p**2+2*a**2*p*(-2+p+e**2*(2+p))))
-           )/(
-               a**4*(-1+e**2)**2+(-4+p)**2*p**2+2*a**2*(-1+e**2)*p*(4+p)
-           )
-    P = 0
-    r1 = p/(1-e)
-    r2 = p/(1+e)
-    r3 = (S+sqrt(S**2-4*P))/2
-    r4 = (S-sqrt(S**2-4*P))/2
-    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
-    L2 = (2*(a**2*(-1+e**2)+p**2)*(a**2-P)+4*a**2*p*S)/(a**2*(2*p+S-e**2*S))
-    #Q = 0
-    #z_minus = 0
-    z_plus = -(p**2+2*p*S)/(a**2*(-1+e**2))
-    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
-    k_theta = 0
-    factor = Lz_sign*sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))
-    return factor*ellipk(k_theta)/ellipk(k_r)
-
-def rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
-    """Ratio of r-frequency and phi-frequency in the equatorial limit
-    
-    Parameters
-    ----------
-    a : double
-        dimensionless spin of the black hole
-    p : double
-        orbital semi-latus rectum
-    e : double
-        orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
-
-    Returns
-    -------
-    double
-    """
-    a = abs(a)
-    if a == 1:
-        raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, 0.5):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    
-    Lz_sign = -1+2*int(is_prograde)
-    P = 0
-    S = 2*(a**4*(-1+e**2)*p+(-4+p)*p**3+a**2*p**2*(3+e**2+p)
-           -Lz_sign*2*sqrt(a**2*p**3*(a**4*(-1+e**2)**2+(-4*e**2+(-2+p)**2)*p**2+2*a**2*p*(-2+p+e**2*(2+p))))
-           )/(
-               a**4*(-1+e**2)**2+(-4+p)**2*p**2+2*a**2*(-1+e**2)*p*(4+p)
-           )
-    P = 0
-    r1 = p/(1-e)
-    r2 = p/(1+e)
-    r3 = (S+sqrt(S**2-4*P))/2
-    r4 = (S-sqrt(S**2-4*P))/2
-    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
-    L2 = (2*(a**2*(-1+e**2)+p**2)*(a**2-P)+4*a**2*p*S)/(a**2*(2*p+S-e**2*S))
-    #Q = 0
-    z_minus = 0
-    z_plus = -(p**2+2*p*S)/(a**2*(-1+e**2))
-    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
-    k_theta = 0
-    factor1 = Lz_sign*sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))
-    rtheta_ratio = factor1*ellipk(k_theta)/ellipk(k_r)
-
-    r_plus = 1+sqrt(1-a**2)
-    r_minus = 1-sqrt(1-a**2)
-    h_r = (r1-r2)/(r1-r3)
-    h_plus = h_r*(r3-r_plus)/(r2-r_plus)
-    h_minus = h_r*(r3-r_minus)/(r2-r_minus)
-    factor2 = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E2)*(r1-r3)*(r2-r4)))
-    B_theta = 2*_ellippi(z_minus, k_theta)*sqrt(L2)/(pi*sqrt((1-E2)*a**2*z_plus))
-    B_r_plus = (2*sqrt(E2)*r_plus-Lz_sign*a*sqrt(L2))/(r3-r_plus)*(ellipk(k_r)-(r2-r3)/(r2-r_plus)*_ellippi(h_plus, k_r))
-    B_r_minus = (2*sqrt(E2)*r_minus-Lz_sign*a*sqrt(L2))/(r3-r_minus)*(ellipk(k_r)-(r2-r3)/(r2-r_minus)*_ellippi(h_minus, k_r))
-    B_r = factor2*(B_r_plus-B_r_minus)
-    return 1/(B_r+B_theta/rtheta_ratio)    
-
-def phitheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
-    """Ratio of phi-frequency and theta-frequency in the equatorial limit
-    
-    Parameters
-    ----------
-    a : double
-        dimensionless spin of the black hole
-    p : double
-        orbital semi-latus rectum
-    e : double
-        orbital eccentricity
-    is_prograde : bool
-        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
-
-    Returns
-    -------
-    double
-    """
-    a = abs(a)
-    if a == 1:
-        raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, 0.5):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    
-    Lz_sign = -1+2*int(is_prograde)
-    P = 0
-    S = 2*(a**4*(-1+e**2)*p+(-4+p)*p**3+a**2*p**2*(3+e**2+p)
-           -Lz_sign*2*sqrt(a**2*p**3*(a**4*(-1+e**2)**2+(-4*e**2+(-2+p)**2)*p**2+2*a**2*p*(-2+p+e**2*(2+p))))
-           )/(
-               a**4*(-1+e**2)**2+(-4+p)**2*p**2+2*a**2*(-1+e**2)*p*(4+p)
-           )
-    P = 0
-    r1 = p/(1-e)
-    r2 = p/(1+e)
-    r3 = (S+sqrt(S**2-4*P))/2
-    r4 = (S-sqrt(S**2-4*P))/2
-    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
-    L2 = (2*(a**2*(-1+e**2)+p**2)*(a**2-P)+4*a**2*p*S)/(a**2*(2*p+S-e**2*S))
-    #Q = 0
-    z_minus = 0
-    z_plus = -(p**2+2*p*S)/(a**2*(-1+e**2))
-    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
-    k_theta = 0
-    factor1 = Lz_sign*sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))
-    rtheta_ratio = factor1*ellipk(k_theta)/ellipk(k_r)
-
-    r_plus = 1+sqrt(1-a**2)
-    r_minus = 1-sqrt(1-a**2)
-    h_r = (r1-r2)/(r1-r3)
-    h_plus = h_r*(r3-r_plus)/(r2-r_plus)
-    h_minus = h_r*(r3-r_minus)/(r2-r_minus)
-    factor2 = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E2)*(r1-r3)*(r2-r4)))
-    B_theta = 2*_ellippi(z_minus, k_theta)*sqrt(L2)/(pi*sqrt((1-E2)*a**2*z_plus))
-    B_r_plus = (2*sqrt(E2)*r_plus-Lz_sign*a*sqrt(L2))/(r3-r_plus)*(ellipk(k_r)-(r2-r3)/(r2-r_plus)*_ellippi(h_plus, k_r))
-    B_r_minus = (2*sqrt(E2)*r_minus-Lz_sign*a*sqrt(L2))/(r3-r_minus)*(ellipk(k_r)-(r2-r3)/(r2-r_minus)*_ellippi(h_minus, k_r))
-    B_r = factor2*(B_r_plus-B_r_minus)
-    return B_r*rtheta_ratio+B_theta
+    ratio = phiInteger/thetaInteger
+    Lz_sign = sign(ratio-1)
+    p0 = _phitheta_resonance_p(a, e, 0, thetaInteger, phiInteger)
+    p1 = _phitheta_resonance_p(a, e, Lz_sign, thetaInteger, phiInteger)
+    if (ratio>1)&((p<p1)|(p0<p)):
+        print(f"p must be in [{p1:f},{p0:f}]")
+        return nan
+    if (ratio<1)&((p<p0)|(p1<p)):
+        print(f"p must be in [{p0:f},{p1:f}]")
+        return nan
+    if p == p0:
+        return 0
+    if p == p1:
+        return 1
+    x0 = Lz_sign*(p-p0)/(p1-p0)
+    resonantEquation = lambda x: _phitheta_frequencyRatio(a, p, e, x)-abs(ratio)
+    return newton(resonantEquation, x0)
 
 # Finding triple resonance
-def tripleResonance_rMode(thetaMode, phiMode, a, e, is_prograde=True):
-    """Find possible r-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
+def _tripleResonance_rInteger(thetaInteger, phiInteger, a, e):
+    """Find possible r-integers sastify omega_r:omega_theta:omega_phi = r-integer:theta-integer:phi-integer.
 
     Parameters
     ----------
@@ -697,15 +713,11 @@ def tripleResonance_rMode(thetaMode, phiMode, a, e, is_prograde=True):
     """
         
     a = abs(a)
-    phitheta_ratio = thetaMode/phiMode
-    Lz_sign = int(is_prograde)*2-1
+    phitheta_ratio = phiInteger/thetaInteger
+    Lz_sign = sign(phitheta_ratio-1)
     
-    if (phitheta_ratio <= 0) | (phitheta_ratio == 1):
-        raise ValueError("The ratio must be positive and not equal to 1")
-    if (phitheta_ratio > 1) & (not is_prograde):
-        raise ValueError("The ratio must be larger than 1 if the orbit is prograde")
-    if (phitheta_ratio < 1) & is_prograde:
-        raise ValueError("The ratio must be lesser than 1 if the orbit is retrograde")
+    if not valid_integers(0, thetaInteger, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     if e == 1:
@@ -713,20 +725,15 @@ def tripleResonance_rMode(thetaMode, phiMode, a, e, is_prograde=True):
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
-    p1 = _doubleResonance_solver(lambda p: abs(phitheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-phitheta_ratio,
-                                 (2*a/abs(phitheta_ratio-1))**(2/3),
-                                 separatrix(a, e, Lz_sign))
-    rtheta_ratio1 = abs(rtheta_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))
+    p0 = _phitheta_resonance_p(a, e, 0, thetaInteger, phiInteger)
+    p1 = _phitheta_resonance_p( a, e, Lz_sign, thetaInteger, phiInteger)
+    rtheta_ratio0 = _rtheta_frequencyRatio(a, p0, e, 0)
+    rtheta_ratio1 = _rtheta_frequencyRatio(a, p1, e, Lz_sign)
     
-    p2 = _doubleResonance_solver(lambda p: abs(phitheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-phitheta_ratio,
-                                 (2*a/abs(phitheta_ratio-1))**(2/3),
-                                 separatrix(a, e, 0))
-    rtheta_ratio2 = abs(rtheta_frequencyRatio_polarLimit(a, p2, e, is_prograde))
-    
-    return sorted([thetaMode/rtheta_ratio1, thetaMode/rtheta_ratio2])
+    return sorted([thetaInteger*rtheta_ratio0, thetaInteger*rtheta_ratio1])
 
-def tripleResonance_thetaMode(rMode, phiMode, a, e, is_prograde=True):
-    """Find possible theta-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
+def _tripleResonance_thetaInteger(rInteger, phiInteger, a, e):
+    """Find possible theta-integers sastify omega_r:omega_theta:omega_phi = r-integer:theta-integer:phi-integer.
 
     Parameters
     ----------
@@ -748,11 +755,11 @@ def tripleResonance_thetaMode(rMode, phiMode, a, e, is_prograde=True):
     """
         
     a = abs(a)
-    rphi_ratio = phiMode/rMode
-    Lz_sign = int(is_prograde)*2-1
+    rphi_ratio = rInteger/phiInteger
+    Lz_sign = sign(rphi_ratio)
     
-    if not valid_frequencyRatio(rphi_ratio):
-        raise ValueError("r-mode must be larger than phi-mode")
+    if not valid_integers(rInteger, 0, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     if e == 1:
@@ -760,19 +767,14 @@ def tripleResonance_thetaMode(rMode, phiMode, a, e, is_prograde=True):
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
-    p1 = _doubleResonance_solver(lambda p: abs(rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rphi_ratio,
-                                 6/(1-rphi_ratio**2),
-                                 separatrix(a, e, Lz_sign))
-    rtheta_ratio1 = abs(rtheta_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))
+    p0 = _rphi_resonance_p(a, e, 0, rInteger, phiInteger)
+    p1 = _rphi_resonance_p(a, e, Lz_sign, rInteger, phiInteger)
+    rtheta_ratio0 = _rtheta_frequencyRatio(a, p0, e, 0)
+    rtheta_ratio1 = _rtheta_frequencyRatio(a, p1, e, Lz_sign)
     
-    p2 = _doubleResonance_solver(lambda p: abs(rphi_frequencyRatio_polarLimit(a, p, e, is_prograde))-rphi_ratio,
-                                 6/(1-rphi_ratio**2),
-                                 separatrix(a, e, 0))
-    rtheta_ratio2 = abs(rtheta_frequencyRatio_polarLimit(a, p2, e, is_prograde))
-    
-    return sorted([rtheta_ratio1*rMode, rtheta_ratio2*rMode])
+    return sorted([rInteger/rtheta_ratio0, rInteger/rtheta_ratio1])
 
-def tripleResonance_phiMode(rMode, thetaMode, a, e, is_prograde=True):
+def _tripleResonance_phiInteger(rInteger, thetaInteger, a, e):
     """Find possible phi-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
 
     Parameters
@@ -795,11 +797,11 @@ def tripleResonance_phiMode(rMode, thetaMode, a, e, is_prograde=True):
     """
         
     a = abs(a)
-    rtheta_ratio = thetaMode/rMode
-    Lz_sign = int(is_prograde)*2-1
+    rtheta_ratio = rInteger/thetaInteger
+    Lz_sign = rtheta_ratio
     
-    if not valid_frequencyRatio(rtheta_ratio):
-        raise ValueError("r-mode must be larger than theta-mode")
+    if not valid_integers(rInteger, thetaInteger, 0):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     if e == 1:
@@ -807,19 +809,17 @@ def tripleResonance_phiMode(rMode, thetaMode, a, e, is_prograde=True):
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
-    p1 = _doubleResonance_solver(lambda p: abs(rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rtheta_ratio,
-                                 6/(1-rtheta_ratio**2),
-                                 separatrix(a, e, Lz_sign))
-    rphi_ratio1 = abs(rphi_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))
+    p0 = _rtheta_resonance_p(a, e, 0, rInteger, thetaInteger)
+    p1 = _rtheta_resonance_p(a, e, Lz_sign, rInteger, thetaInteger)
+    if Lz_sign > 0:
+        rphi_ratio0 = _rphi_frequencyRatio(a, p0, e, 0)[0]
+    elif Lz_sign < 0:
+        rphi_ratio0 = _rphi_frequencyRatio(a, p0, e, 0)[1]
+    rphi_ratio1 = _rphi_frequencyRatio(a, p1, e, Lz_sign)
     
-    p2 = _doubleResonance_solver(lambda p: abs(rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-rtheta_ratio,
-                                 6/(1-rtheta_ratio**2),
-                                 separatrix(a, e, 0))
-    rphi_ratio2 = abs(rphi_frequencyRatio_polarLimit(a, p2, e, is_prograde))
-    
-    return sorted([rphi_ratio1*rMode, rphi_ratio2*rMode])
+    return sorted([rInteger/rphi_ratio0, rInteger/rphi_ratio1])
 
-def tripleResonance(rMode, thetaMode, phiMode, a, e, is_prograde=True):
+def _tripleResonance(a, e, rInteger, thetaInteger, phiInteger):
     """Find (p, x) from resonant modes
 
     Parameters
@@ -844,14 +844,12 @@ def tripleResonance(rMode, thetaMode, phiMode, a, e, is_prograde=True):
     """
     
     a = abs(a)
-    rtheta_ratio = thetaMode/rMode
-    rphi_ratio = phiMode/rMode
-    Lz_sign = int(is_prograde)*2-1
+    rtheta_ratio = rInteger/thetaInteger
+    rphi_ratio = rInteger/phiInteger
+    Lz_sign = sign(rtheta_ratio)
     
-    if not valid_frequencyRatio(rtheta_ratio):
-        raise ValueError("Require r-mode > theta-mode > 0")
-    if not valid_frequencyRatio(rphi_ratio):
-        raise ValueError("Require r-mode > phi-mode > 0")
+    if not valid_integers(rInteger, thetaInteger, phiInteger):
+        raise ValueError("Require |rInteger| > |thetaInteger|, |rInteger| > |phiInteger| and thetaInteger*phiInteger>0")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     if e == 1:
@@ -859,27 +857,73 @@ def tripleResonance(rMode, thetaMode, phiMode, a, e, is_prograde=True):
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")  
 
-    sep1 = separatrix(a, e, Lz_sign)
-    sep2 = separatrix(a, e, 0)
-    p0_rtheta = 6/(1-rtheta_ratio**2)
-    p0_rphi = 6/(1-rphi_ratio**2)
-    p1_rtheta = _doubleResonance_solver(lambda p: abs(rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rtheta_ratio, p0_rtheta, sep1)
-    p1_rphi = _doubleResonance_solver(lambda p: abs(rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rphi_ratio, p0_rphi, sep1)
-    p2_rtheta = _doubleResonance_solver(lambda p: abs(rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-rtheta_ratio, p0_rtheta, sep2)
-    p2_rphi = _doubleResonance_solver(lambda p: abs(rphi_frequencyRatio_polarLimit(a, p, e, is_prograde))-rphi_ratio, p0_rphi, sep2)    
+    p0_rtheta = _rtheta_resonance_p(a, e, 0, rInteger, thetaInteger)
+    p1_rtheta = _rtheta_resonance_p(a, e, Lz_sign, rInteger, thetaInteger)
+    p0_rphi = _rphi_resonance_p(a, e, 0, rInteger, phiInteger)
+    p1_rphi = _rphi_resonance_p(a, e, Lz_sign, rInteger, phiInteger)
                                    
-    check_if_having_solution = (p1_rtheta-p1_rphi)*(p2_rtheta-p2_rphi)
+    check_if_having_solution = (p0_rtheta-p0_rphi)*(p1_rtheta-p1_rphi)
     
     if (check_if_having_solution > 0) | (check_if_having_solution == nan):
+        rs = _tripleResonance_rInteger(thetaInteger, phiInteger, a, e)
+        thetas = _tripleResonance_phiInteger(rInteger, thetaInteger, a, e)
+        phis = _tripleResonance_thetaInteger(rInteger, phiInteger, a, e)
+        print("No triple resonance, try changing one of the integers:")
+        print(f"Choose r-integer in [{rs[0]:f}, {rs[1]:f}]")
+        print(f"Choose phi-integer in [{thetas[0]:f}, {thetas[1]:f}]")
+        print(f"Choose theta-integer in [{phis[0]:f}, {phis[1]:f}]")
         return [nan, nan]
     elif check_if_having_solution < 0:
-        x0 = Lz_sign/((p1_rphi-p1_rtheta)/(p2_rtheta-p2_rphi)+1)
-        p0 = p2_rtheta-Lz_sign*x0*(p2_rtheta-p1_rtheta)
-        sol = fsolve(lambda X: [abs(_rtheta_frequencyRatio(a, X[0], e, X[1]))-rtheta_ratio,
-                                abs(_rphi_frequencyRatio(a, X[0], e, X[1]))-rphi_ratio], [p0, x0])
+        x0 = Lz_sign/((p1_rphi-p1_rtheta)/(p0_rtheta-p0_rphi)+1)
+        p0 = p0_rtheta-Lz_sign*x0*(p0_rtheta-p1_rtheta)
+        sol = fsolve(lambda X: [_rtheta_frequencyRatio(a, X[0], e, X[1])-abs(rtheta_ratio),
+                                _rphi_frequencyRatio(a, X[0], e, X[1])-abs(rphi_ratio)], [p0, x0])
         return sol
     else:
-        if (p1_rtheta-p1_rphi) == 0:
-            return [p1_rtheta, Lz_sign]
+        if (p0_rtheta-p0_rphi) == 0:
+            return [p0_rtheta, Lz_sign]
         else:
-            return [p2_rtheta, 0]
+            return [p1_rtheta, 0]
+        
+# Generic function
+
+def findResonance(a, p=None, e=None, x=None, integers=[0,0,0]):
+    rInteger, thetaInteger, phiInteger = integers
+    if (rInteger!=0) & (thetaInteger!=0) & (phiInteger!=0):
+        if e != None:
+            return _tripleResonance(a, e, rInteger, thetaInteger, phiInteger)
+        else: 
+            raise ValueError("Only support finding (p,x) with given (a,e)")
+        
+    elif (rInteger==0) & (thetaInteger!=0) & (phiInteger!=0):
+        if (p==None) & (e!=None) & (x!=None):
+            return _phitheta_resonance_p(a, e, x, thetaInteger, phiInteger)
+        elif (p!=None) & (e==None) & (x!=None):
+            return _phitheta_resonance_e(a, p, x, thetaInteger, phiInteger)
+        elif (p!=None) & (e!=None) & (x==None):
+            return _phitheta_resonance_x(a, p, e, thetaInteger, phiInteger)
+        else: 
+            raise ValueError("Require 2 of (p, e, x)")
+        
+    elif (rInteger!=0) & (thetaInteger==0) & (phiInteger!=0):
+        if (p==None) & (e!=None) & (x!=None):
+            return _rphi_resonance_p(a, e, x, rInteger, phiInteger)
+        elif (p!=None) & (e==None) & (x!=None):
+            return _rphi_resonance_e(a, p, x, rInteger, phiInteger)
+        elif (p!=None) & (e!=None) & (x==None):
+            return _rphi_resonance_x(a, p, e, rInteger, phiInteger)
+        else: 
+            raise ValueError("Require 2 of (p, e, x)")
+        
+    elif (rInteger!=0) & (thetaInteger!=0) & (phiInteger==0):
+        if (p==None) & (e!=None) & (x!=None):
+            return _rtheta_resonance_p(a, e, x, rInteger, thetaInteger)
+        elif (p!=None) & (e==None) & (x!=None):
+            return _rtheta_resonance_e(a, p, x, rInteger, thetaInteger)
+        elif (p!=None) & (e!=None) & (x==None):
+            return _rtheta_resonance_x(a, p, e, rInteger, thetaInteger)
+        else: 
+            raise ValueError("Require 2 of (p, e, x)")
+        
+    else:
+        raise ValueError("At least 2 of the integers are non-zero")        

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -4,7 +4,7 @@ from .frequencies import *
 from .frequencies import _ellippi
 from .constants import *
 from .constants import _standardize_params
-from scipy.optimize import fsolve, newton
+from scipy.optimize import fsolve, newton, root_scalar
 from scipy.special import elliprf
 from numpy import sqrt, pi, sign
 
@@ -165,7 +165,7 @@ def _phitheta_frequencyRatio(a, p, e, x):
     h_plus = (r1 - r2) * (r3 - r_plus) / ((r1 - r3) * (r2 - r_plus))
     h_minus = (r1 - r2) * (r3 - r_minus) / ((r1 - r3) * (r2 - r_minus))
     
-    # simplified form of epsilon0*z_plus
+    #simplified form of epsilon0*z_plus
     e0zp = (a**2 * (1 - E**2) * (1 - z_minus) + L**2) / (L**2 * (1 - z_minus))
     
     #theta-r ratio
@@ -191,6 +191,42 @@ def _phitheta_frequencyRatio(a, p, e, x):
 
 # Finding resonance
 ## In general 
+
+def _doubleResonance_solver(equation, p0, sep):
+    '''Try `scipy.newton` twive with different initial guess, one of them is very near the separatrix
+    
+    Parameters
+    ----------
+    equation: callable
+        resonant condition equation needed to be solved
+    p0 : double
+        initial guess p of the first attemp
+    sep : double
+        initial guess p of the second attemp, which also is p at the separatrix
+    
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    '''
+    try:
+        p_sol = newton(equation, p0)
+    except RuntimeError:
+        try:
+            p_sol = root_scalar(equation, method="brentq", bracket=(sep+1e-5, p0)).root
+        except:
+            try:
+                p_sol = newton(equation, sep+1e-5)
+            except RuntimeError:
+                pass
+            else:
+                return p_sol
+        else:
+            return p_sol
+    else:
+        return p_sol
+    raise RuntimeError("p is too close to the separatrix")
+    
 def rtheta_resonance(ratio, a, e, x):
     """Return p of r-theta resonant orbit
     
@@ -223,24 +259,10 @@ def rtheta_resonance(ratio, a, e, x):
         raise ValueError("Marginally bound orbits not supported")
     if not valid_params(a, e, x):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    
-    p_sol = None
-    try:
-        p0 = 6/(1-ratio**2)
-        p1 = separatrix(a, e, x)+1e-10
-        p_sol = newton(lambda p: abs(_rtheta_frequencyRatio(a, p, e, x))-ratio, x0=p0, x1=p1)
-    except ValueError:
-        try:
-            p0 = separatrix(a, e, x)+1e-10
-            p_sol = newton(lambda p: abs(_rtheta_frequencyRatio(a, p, e, x))-ratio, x0=p0)
-        except ValueError:
-            pass
-        else:
-            return p_sol    
-    else:
-        return p_sol
-    if not p_sol:
-        raise ValueError("p is too close to that of the separatrix.")
+
+    return _doubleResonance_solver(lambda p: abs(_rtheta_frequencyRatio(a, p, e, x))-ratio,
+                                   6/(1-ratio**2),
+                                   separatrix(a, e, x))
 
 def rphi_resonance(ratio, a, e, x):
     """Return p of r-phi resonant orbit
@@ -275,23 +297,9 @@ def rphi_resonance(ratio, a, e, x):
     if not valid_params(a, e, x):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
-    p_sol = None
-    try:
-        p0 = 6/(1-ratio**2)
-        p1 = separatrix(a, e, x)+1e-10
-        p_sol = newton(lambda p: abs(_rphi_frequencyRatio(a, p, e, x))-ratio, x0=p0, x1=p1)
-    except ValueError:
-        try:
-            p0 = separatrix(a, e, x)+1e-10
-            p_sol = newton(lambda p: abs(_rphi_frequencyRatio(a, p, e, x))-ratio, x0=p0)
-        except ValueError:
-            pass
-        else:
-            return p_sol    
-    else:
-        return p_sol
-    if not p_sol:
-        raise ValueError("p is too close to that of the separatrix.")
+    return _doubleResonance_solver(lambda p: abs(_rphi_frequencyRatio(a, p, e, x))-ratio,
+                                   6/(1-ratio**2),
+                                   separatrix(a, e, x))
 
 def phitheta_resonance(ratio, a, e, x):
     """Return p of phi-theta resonant orbit
@@ -329,23 +337,9 @@ def phitheta_resonance(ratio, a, e, x):
     if not valid_params(a, e, x):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
-    p_sol = None
-    try:
-        p0 = (2*a/abs(ratio**2-1))**(2/3)
-        p1 = separatrix(a, e, x)+1e-10
-        p_sol = newton(lambda p: abs(_phitheta_frequencyRatio(a, p, e, x))-ratio, x0=p0, x1=p1)
-    except ValueError: 
-        try:
-            p0 = separatrix(a, e, x)+1e-10
-            p_sol = newton(lambda p: abs(_phitheta_frequencyRatio(a, p, e, x))-ratio, x0=p0)
-        except ValueError:
-            pass
-        else:
-            return p_sol
-    else:
-        return p_sol
-    if not p_sol:
-        raise ValueError("p is too close to that of the separatrix.")
+    return _doubleResonance_solver(lambda p: abs(_phitheta_frequencyRatio(a, p, e, x))-ratio,
+                                   (2*a/abs(ratio-1))**(2/3),
+                                   separatrix(a, e, x))
 
 # Frequency ratio of r-theta and r-phi in special limits (support finding triple resonance)
 ## In the polar limit
@@ -439,6 +433,59 @@ def rphi_frequencyRatio_polarLimit(a, p, e, is_prograde=True):
     B_r = factor2*(B_r_plus-B_r_minus)
     #B_theta = 1
     return 1/(B_r+1/rtheta_ratio)
+
+def phitheta_frequencyRatio_polarLimit(a, p, e, is_prograde=True):
+    """Ratio of phi-frequency and theta-frequency in the polar limit
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+
+    Returns
+    -------
+    double
+    """
+    Lz_sign = -1+2*int(is_prograde)
+    P = (a**2*(a**4*(-1+e**2)*2+p**4+2*a**2*p*(-2+p+e**2*(2+p)))
+         )/(
+             a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
+    S = (2*(a**2*(-1+e**2)+p**2)**2
+         )/(
+            a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
+    r1 = p/(1-e)
+    r2 = p/(1+e)
+    r3 = (S+sqrt(S**2-4*P))/2
+    r4 = (S-sqrt(S**2-4*P))/2
+    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
+    Q = 2*p**2*P/(a**2*(2*p+S-e**2*S))
+    #L2 = 0
+    #z2 = 1
+    #z1 = Q/(1-E2)/a**2/z2
+    
+    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
+    k_theta = (1-E2)*a**2/Q
+    factor1 = Lz_sign*sqrt((r1-r3)*(r2-r4)*2*(1-e**2)*a**2/(2*p**2*P))
+    rtheta_ratio = factor1*ellipk(k_theta)/ellipk(k_r)
+    
+    r_plus = 1+sqrt(1-a**2)
+    r_minus = 1-sqrt(1-a**2)
+    h_r = (r1-r2)/(r1-r3)
+    h_plus = h_r*(r3-r_plus)/(r2-r_plus)
+    h_minus = h_r*(r3-r_minus)/(r2-r_minus)
+    factor2 = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E2)*(r1-r3)*(r2-r4)))*2*sqrt(E2)
+    B_r_plus = r_plus/(r3-r_plus)*(ellipk(k_r)-(r2-r3)/(r2-r_plus)*_ellippi(h_plus, k_r))
+    B_r_minus = r_minus/(r3-r_minus)*(ellipk(k_r)-(r2-r3)/(r2-r_minus)*_ellippi(h_minus, k_r))
+    B_r = factor2*(B_r_plus-B_r_minus)
+    #B_theta = 1
+    return B_r*rtheta_ratio+1
+
 
 ## In the equatorial limit
 def rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
@@ -534,16 +581,68 @@ def rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
     B_r = factor2*(B_r_plus-B_r_minus)
     return 1/(B_r+B_theta/rtheta_ratio)    
 
+def phitheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
+    """Ratio of phi-frequency and theta-frequency in the equatorial limit
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+
+    Returns
+    -------
+    double
+    """
+    Lz_sign = -1+2*int(is_prograde)
+    P = 0
+    S = 2*(a**4*(-1+e**2)*p+(-4+p)*p**3+a**2*p**2*(3+e**2+p)
+           -Lz_sign*2*sqrt(a**2*p**3*(a**4*(-1+e**2)**2+(-4*e**2+(-2+p)**2)*p**2+2*a**2*p*(-2+p+e**2*(2+p))))
+           )/(
+               a**4*(-1+e**2)**2+(-4+p)**2*p**2+2*a**2*(-1+e**2)*p*(4+p)
+           )
+    P = 0
+    r1 = p/(1-e)
+    r2 = p/(1+e)
+    r3 = (S+sqrt(S**2-4*P))/2
+    r4 = (S-sqrt(S**2-4*P))/2
+    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
+    L2 = (2*(a**2*(-1+e**2)+p**2)*(a**2-P)+4*a**2*p*S)/(a**2*(2*p+S-e**2*S))
+    #Q = 0
+    z_minus = 0
+    z_plus = -(p**2+2*p*S)/(a**2*(-1+e**2))
+    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
+    k_theta = 0
+    factor1 = Lz_sign*sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))
+    rtheta_ratio = factor1*ellipk(k_theta)/ellipk(k_r)
+
+    r_plus = 1+sqrt(1-a**2)
+    r_minus = 1-sqrt(1-a**2)
+    h_r = (r1-r2)/(r1-r3)
+    h_plus = h_r*(r3-r_plus)/(r2-r_plus)
+    h_minus = h_r*(r3-r_minus)/(r2-r_minus)
+    factor2 = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E2)*(r1-r3)*(r2-r4)))
+    B_theta = 2*_ellippi(z_minus, k_theta)*sqrt(L2)/(pi*sqrt((1-E2)*a**2*z_plus))
+    B_r_plus = (2*sqrt(E2)*r_plus-Lz_sign*a*sqrt(L2))/(r3-r_plus)*(ellipk(k_r)-(r2-r3)/(r2-r_plus)*_ellippi(h_plus, k_r))
+    B_r_minus = (2*sqrt(E2)*r_minus-Lz_sign*a*sqrt(L2))/(r3-r_minus)*(ellipk(k_r)-(r2-r3)/(r2-r_minus)*_ellippi(h_minus, k_r))
+    B_r = factor2*(B_r_plus-B_r_minus)
+    return B_r*rtheta_ratio+B_theta
+
 # Finding triple resonance
-def tripleResonance_phiMode(rMode, thetaMode, a, e, is_prograde=True):
-    """Find possible phi-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
+def tripleResonance_rMode(thetaMode, phiMode, a, e, is_prograde=True):
+    """Find possible r-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
 
     Parameters
     ----------
     rMode : double
         radial mode
-    thetaMode : double
-        polar-angle mode
+    phiMode : double
+        azimuthal-angle mode
     a : double
         dimensionless spin of the black hole
     e : double
@@ -554,32 +653,37 @@ def tripleResonance_phiMode(rMode, thetaMode, a, e, is_prograde=True):
     Returns
     ------- 
     (double, double)
-        Boundaries of the posible phi-mode.
+        Boundaries of the posible theta-mode.
     """
         
     a = abs(a)
-    rtheta_ratio = thetaMode/rMode
+    phitheta_ratio = thetaMode/phiMode
     Lz_sign = int(is_prograde)*2-1
     
-    if not valid_frequencyRatio(rtheta_ratio):
-        raise ValueError("r-mode must be larger than theta-mode")
+    if (phitheta_ratio <= 0) | (phitheta_ratio == 1):
+        raise ValueError("The ratio must be positive and not equal to 1")
+    if (phitheta_ratio > 1) & (not is_prograde):
+        raise ValueError("The ratio must be larger than 1 if the orbit is prograde")
+    if (phitheta_ratio < 1) & is_prograde:
+        raise ValueError("The ratio must be lesser than 1 if the orbit is retrograde")
     if a == 1:
         raise ValueError("Extreme Kerr not supported")
     if e == 1:
         raise ValueError("Marginally bound orbits not supported")
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
+
+    p1 = _doubleResonance_solver(lambda p: abs(phitheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-phitheta_ratio,
+                                 (2*a/abs(phitheta_ratio-1))**(2/3),
+                                 separatrix(a, e, Lz_sign))
+    rtheta_ratio1 = abs(rtheta_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))
     
-    p1 = newton(lambda p: abs(rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rtheta_ratio,
-                6/(1-rtheta_ratio**2))
-    p2 = newton(lambda p: abs(rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-rtheta_ratio,
-                6/(1-rtheta_ratio**2))
-    k1 = newton(lambda rphi_ratio: abs(rphi_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))-rphi_ratio,
-                rtheta_ratio)
-    k2 = newton(lambda rphi_ratio: abs(rphi_frequencyRatio_polarLimit(a, p2, e, is_prograde))-rphi_ratio,
-                rtheta_ratio)
+    p2 = _doubleResonance_solver(lambda p: abs(phitheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-phitheta_ratio,
+                                 (2*a/abs(phitheta_ratio-1))**(2/3),
+                                 separatrix(a, e, 0))
+    rtheta_ratio2 = abs(rtheta_frequencyRatio_polarLimit(a, p2, e, is_prograde))
     
-    return sorted([k1*rMode, k2*rMode])
+    return sorted([thetaMode/rtheta_ratio1, thetaMode/rtheta_ratio2])
 
 def tripleResonance_thetaMode(rMode, phiMode, a, e, is_prograde=True):
     """Find possible theta-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
@@ -615,17 +719,65 @@ def tripleResonance_thetaMode(rMode, phiMode, a, e, is_prograde=True):
         raise ValueError("Marginally bound orbits not supported")
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
+
+    p1 = _doubleResonance_solver(lambda p: abs(rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rphi_ratio,
+                                 6/(1-rphi_ratio**2),
+                                 separatrix(a, e, Lz_sign))
+    rtheta_ratio1 = abs(rtheta_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))
     
-    p1 = newton(lambda p: abs(rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rphi_ratio,
-                6/(1-rphi_ratio**2))
-    p2 = newton(lambda p: abs(rphi_frequencyRatio_polarLimit(a, p, e, is_prograde))-rphi_ratio,
-                6/(1-rphi_ratio**2))
-    k1 = newton(lambda rtheta_ratio: abs(rtheta_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))-rtheta_ratio,
-                rphi_ratio)
-    k2 = newton(lambda rtheta_ratio: abs(rtheta_frequencyRatio_polarLimit(a, p2, e, is_prograde))-rtheta_ratio,
-                rphi_ratio)
+    p2 = _doubleResonance_solver(lambda p: abs(rphi_frequencyRatio_polarLimit(a, p, e, is_prograde))-rphi_ratio,
+                                 6/(1-rphi_ratio**2),
+                                 separatrix(a, e, 0))
+    rtheta_ratio2 = abs(rtheta_frequencyRatio_polarLimit(a, p2, e, is_prograde))
     
-    return sorted([k1*rMode, k2*rMode])
+    return sorted([rtheta_ratio1*rMode, rtheta_ratio2*rMode])
+
+def tripleResonance_phiMode(rMode, thetaMode, a, e, is_prograde=True):
+    """Find possible phi-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
+
+    Parameters
+    ----------
+    rMode : double
+        radial mode
+    thetaMode : double
+        polar-angle mode
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+    
+    Returns
+    ------- 
+    (double, double)
+        Boundaries of the posible phi-mode.
+    """
+        
+    a = abs(a)
+    rtheta_ratio = thetaMode/rMode
+    Lz_sign = int(is_prograde)*2-1
+    
+    if not valid_frequencyRatio(rtheta_ratio):
+        raise ValueError("r-mode must be larger than theta-mode")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, 0.5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+
+    p1 = _doubleResonance_solver(lambda p: abs(rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rtheta_ratio,
+                                 6/(1-rtheta_ratio**2),
+                                 separatrix(a, e, Lz_sign))
+    rphi_ratio1 = abs(rphi_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))
+    
+    p2 = _doubleResonance_solver(lambda p: abs(rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-rtheta_ratio,
+                                 6/(1-rtheta_ratio**2),
+                                 separatrix(a, e, 0))
+    rphi_ratio2 = abs(rphi_frequencyRatio_polarLimit(a, p2, e, is_prograde))
+    
+    return sorted([rphi_ratio1*rMode, rphi_ratio2*rMode])
 
 def tripleResonance(rMode, thetaMode, phiMode, a, e, is_prograde=True):
     """Find (p, x) from resonant modes
@@ -656,7 +808,6 @@ def tripleResonance(rMode, thetaMode, phiMode, a, e, is_prograde=True):
     rphi_ratio = phiMode/rMode
     Lz_sign = int(is_prograde)*2-1
     
-    
     if not valid_frequencyRatio(rtheta_ratio):
         raise ValueError("Require r-mode > theta-mode > 0")
     if not valid_frequencyRatio(rphi_ratio):
@@ -668,31 +819,25 @@ def tripleResonance(rMode, thetaMode, phiMode, a, e, is_prograde=True):
     if not valid_params(a, e, 0.5):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")  
 
-    p1_rtheta = newton(lambda p: abs(rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rtheta_ratio,
-                       6/(1-rtheta_ratio**2))
-    p2_rtheta = newton(lambda p: abs(rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-rtheta_ratio,
-                       6/(1-rtheta_ratio**2))
-    p1_rphi = newton(lambda p: abs(rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rphi_ratio,
-                    6/(1-rphi_ratio**2))
-    p2_rphi = newton(lambda p: abs(rphi_frequencyRatio_polarLimit(a, p, e, is_prograde))-rphi_ratio,
-                    6/(1-rphi_ratio**2))
-
+    sep1 = separatrix(a, e, Lz_sign)
+    sep2 = separatrix(a, e, 0)
+    p0_rtheta = 6/(1-rtheta_ratio**2)
+    p0_rphi = 6/(1-rphi_ratio**2)
+    p1_rtheta = _doubleResonance_solver(lambda p: abs(rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rtheta_ratio, p0_rtheta, sep1)
+    p1_rphi = _doubleResonance_solver(lambda p: abs(rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rphi_ratio, p0_rphi, sep1)
+    p2_rtheta = _doubleResonance_solver(lambda p: abs(rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-rtheta_ratio, p0_rtheta, sep2)
+    p2_rphi = _doubleResonance_solver(lambda p: abs(rphi_frequencyRatio_polarLimit(a, p, e, is_prograde))-rphi_ratio, p0_rphi, sep2)    
+                                   
     check_if_having_solution = (p1_rtheta-p1_rphi)*(p2_rtheta-p2_rphi)
-
     
     if (check_if_having_solution > 0) | (check_if_having_solution == nan):
         return [nan, nan]
-
     elif check_if_having_solution < 0:
-        if abs(p1_rtheta-p1_rphi) < abs(p2_rtheta-p2_rphi):
-            p0 = (p1_rtheta+p1_rphi)/2
-        else: 
-            p0 = (p2_rtheta+p2_rphi)/2
-        x0 = Lz_sign*0.5
+        x0 = Lz_sign/((p1_rphi-p1_rtheta)/(p2_rtheta-p2_rphi)+1)
+        p0 = p2_rtheta-Lz_sign*x0*(p2_rtheta-p1_rtheta)
         sol = fsolve(lambda X: [abs(_rtheta_frequencyRatio(a, X[0], e, X[1]))-rtheta_ratio,
                                 abs(_rphi_frequencyRatio(a, X[0], e, X[1]))-rphi_ratio], [p0, x0])
         return sol
-    
     else:
         if (p1_rtheta-p1_rphi) == 0:
             return [p1_rtheta, Lz_sign]

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -224,16 +224,23 @@ def rtheta_resonance(ratio, a, e, x):
     if not valid_params(a, e, x):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
     
+    p_sol = None
     try:
         p0 = 6/(1-ratio**2)
         p1 = separatrix(a, e, x)+1e-10
         p_sol = newton(lambda p: abs(_rtheta_frequencyRatio(a, p, e, x))-ratio, x0=p0, x1=p1)
     except ValueError:
-        p0 = separatrix(a, e, x)+1e-10
-        p_sol = newton(lambda p: abs(_rtheta_frequencyRatio(a, p, e, x))-ratio, x0=p0)
-        return p_sol    
+        try:
+            p0 = separatrix(a, e, x)+1e-10
+            p_sol = newton(lambda p: abs(_rtheta_frequencyRatio(a, p, e, x))-ratio, x0=p0)
+        except ValueError:
+            pass
+        else:
+            return p_sol    
     else:
         return p_sol
+    if not p_sol:
+        raise ValueError("p is too close to that of the separatrix.")
 
 def rphi_resonance(ratio, a, e, x):
     """Return p of r-phi resonant orbit
@@ -268,16 +275,23 @@ def rphi_resonance(ratio, a, e, x):
     if not valid_params(a, e, x):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
+    p_sol = None
     try:
         p0 = 6/(1-ratio**2)
         p1 = separatrix(a, e, x)+1e-10
         p_sol = newton(lambda p: abs(_rphi_frequencyRatio(a, p, e, x))-ratio, x0=p0, x1=p1)
     except ValueError:
-        p0 = separatrix(a, e, x)+1e-10
-        p_sol = newton(lambda p: abs(_rphi_frequencyRatio(a, p, e, x))-ratio, x0=p0)
-        return p_sol    
+        try:
+            p0 = separatrix(a, e, x)+1e-10
+            p_sol = newton(lambda p: abs(_rphi_frequencyRatio(a, p, e, x))-ratio, x0=p0)
+        except ValueError:
+            pass
+        else:
+            return p_sol    
     else:
         return p_sol
+    if not p_sol:
+        raise ValueError("p is too close to that of the separatrix.")
 
 def phitheta_resonance(ratio, a, e, x):
     """Return p of phi-theta resonant orbit
@@ -300,8 +314,8 @@ def phitheta_resonance(ratio, a, e, x):
     """
     
     a, x = _standardize_params(a, x)
-    if ratio <= 0:
-        raise ValueError("The ratio must be positive")
+    if (ratio <= 0) | (ratio == 1):
+        raise ValueError("The ratio must be positive and not equal to 1")
     if (ratio > 1) & (x < 0):
         raise ValueError("The ratio must be larger than 1 if the orbit is prograde")
     if (ratio < 1) & (x > 0):
@@ -315,91 +329,23 @@ def phitheta_resonance(ratio, a, e, x):
     if not valid_params(a, e, x):
         raise ValueError("a^2, e and x^2 must be between 0 and 1")
 
-    p0 = separatrix(a, e, x)+1e-10
-    p_sol = newton(lambda p: abs(_phitheta_frequencyRatio(a, p, e, x))-ratio, x0=p0)
-    return p_sol
-
-## In the weak-field limit (only r-theta and r-phi)
-def rtheta_resonance_weakFieldLimit(ratio, a, p, e):
-    """Return approximated cos^2(theta) of r-theta resonant orbit in the weak-field limit
-
-    Parameters
-    ----------
-    ratio: double
-        r-phi frequency ratio
-    a : double
-        dimensionless spin of the black hole
-    p : double
-        orbital semi-latus rectum
-    e : double
-        orbital eccentricity
-
-    Returns
-    -------
-    z_minus : double
-        squared cosine of the polar angle
-    """
-    a = abs(a)
-    
-    if not valid_frequencyRatio(ratio):
-        raise ValueError("The ratio must be between 0 and 1")
-    if a == 1:
-        raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, .5):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    
-    p0 = 6/(1-ratio**2)
-    return (
-        (4 * a**2 + e**2 - (6 * e**2 + 4 * p**2) / p0) / (a**2 * (5 - 6 * e**2 / p0)) 
-        - (12 * p * (2 * e**2 / p0 + 1)) / (a**2 * (5 - 6 * e**2 / p0)**2)
-        + (8 / a**2) * np.sqrt(
-            (p * (a**2 - e**2 + (6 * e**2 * (1 - a**2) + 4 * p**2) / p0)) / (5 - 6 * e**2 / p0)**3 
-            - (4 * p**2 * (1 - 6 * e**2 / p0)) / (5 - 6 * e**2 / p0)**4
-        ))
-
-def rphi_resonance_weakFieldLimit(ratio, a, p, e, is_prograde=True):
-    """Return approximated p of r-phi resonant orbit in the weak-field limit
-
-    Parameters
-    ----------
-    ratio: double
-        r-phi frequency ratio
-    a : double
-        dimensionless spin of the black hole
-    e : double
-        orbital eccentricity
-    p : double
-        orbital semi-latus rectum
-
-    Returns
-    -------
-    
-    z_minus : double
-        squared cosine of the polar angle
-    """
-    
-    a = abs(a)
-    
-    if not valid_frequencyRatio(ratio):
-        raise ValueError("The ratio must be between 0 and 1")
-    if a == 1:
-        raise ValueError("Extreme Kerr not supported")
-    if e == 1:
-        raise ValueError("Marginally bound orbits not supported")
-    if not valid_params(a, e, 0.5):
-        raise ValueError("a^2, e and x^2 must be between 0 and 1")
-    
-    k_rtheta = lambda x: (2*(-6+p)*p+24*a*sqrt(p)*x
-                          +3*a**2*(1-5*x**2+e**2*(-1+x**2))
-                          )/(
-                              2*p**2+3*e**2*(1+a**2*(-1+x**2)))
-    Lz_sign = 2*int(is_prograde)-1
-    equation = lambda x: abs(Lz_sign/sqrt(k_rtheta(x))*(1+a**2*(1-e**2)*(1-abs(x))/2/p**2)
-                             +2*a/p**(3/2)+(-a**2*x-5*e**2*a**2*x/4)/p**2)-1/ratio
-    x_sol = newton(equation, x0=0.5*Lz_sign)
-    return 1-x_sol**2
+    p_sol = None
+    try:
+        p0 = (2*a/abs(ratio**2-1))**(2/3)
+        p1 = separatrix(a, e, x)+1e-10
+        p_sol = newton(lambda p: abs(_phitheta_frequencyRatio(a, p, e, x))-ratio, x0=p0, x1=p1)
+    except ValueError: 
+        try:
+            p0 = separatrix(a, e, x)+1e-10
+            p_sol = newton(lambda p: abs(_phitheta_frequencyRatio(a, p, e, x))-ratio, x0=p0)
+        except ValueError:
+            pass
+        else:
+            return p_sol
+    else:
+        return p_sol
+    if not p_sol:
+        raise ValueError("p is too close to that of the separatrix.")
 
 # Frequency ratio of r-theta and r-phi in special limits (support finding triple resonance)
 ## In the polar limit

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -585,7 +585,7 @@ def rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
 
 # Finding triple resonance
 def tripleResonance_phiMode(rMode, thetaMode, a, e, is_prograde=True):
-    """Find possible phi resonant modes from r-mode and theta-mode.
+    """Find possible phi-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
 
     Parameters
     ----------
@@ -631,7 +631,7 @@ def tripleResonance_phiMode(rMode, thetaMode, a, e, is_prograde=True):
     return sorted([k1*rMode, k2*rMode])
 
 def tripleResonance_thetaMode(rMode, phiMode, a, e, is_prograde=True):
-    """Find possible theta resonant modes from r-mode and phi-mode.
+    """Find possible theta-modes sastify rMode*omega_r=thetaMode*omega_theta=phiMode*omega_phi.
 
     Parameters
     ----------
@@ -675,7 +675,7 @@ def tripleResonance_thetaMode(rMode, phiMode, a, e, is_prograde=True):
                 rphi_ratio)
     
     return sorted([k1*rMode, k2*rMode])
-    
+
 def tripleResonance(rMode, thetaMode, phiMode, a, e, is_prograde=True):
     """Find (p, x) from resonant modes
 

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -8,12 +8,6 @@ from scipy.optimize import fsolve, newton, root_scalar
 from scipy.special import elliprf, ellipk
 from numpy import sqrt, pi, sign
 
-def valid_frequencyRatio(ratio):
-    if (0 < abs(ratio)) & (abs(ratio) < 1):
-        return True
-    else:
-        return False
-
 def valid_integers(r, phi, theta):
     if r < 0:
         return False

--- a/kerrgeopy/resonance.py
+++ b/kerrgeopy/resonance.py
@@ -1,0 +1,750 @@
+"""Module containing functions for finding resonance orbits
+"""
+from .frequencies import *
+from .frequencies import _ellippi
+from .constants import *
+from .constants import _standardize_params
+from scipy.optimize import fsolve, newton
+from scipy.special import elliprf
+from numpy import sqrt, pi, sign
+
+def valid_frequencyRatio(ratio):
+    if (0 < ratio) & (ratio < 1):
+        return True
+    else:
+        return False
+
+def _rtheta_frequencyRatio(a, p, e, x):
+    """Ratio of r-frequency and theta-frequency  
+
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    double
+    """
+    a, x = _standardize_params(a, x)
+    
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    
+    
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    if not is_stable(a, p, e, x):
+        raise ValueError("Not a stable orbit")
+
+    r1, r2, r3, r4 = stable_radial_roots(a, p, e, x)
+    z_minus, z_plus = stable_polar_roots(a, p, e, x)
+
+    y1 = (p**2-p*(r3+r4))/(1-e**2)+r3*r4
+    y2 = a**2/2*(2*z_plus-z_minus)
+    d1 = e*p*(r4-r3)/(1-e**2)
+    d2 = -a**2*z_minus/2
+
+    return sign(x)*sqrt(y1/y2)*elliprf(0, 1+d2/y2, 1-d2/y2)/elliprf(0, 1+d1/y1, 1-d1/y1)
+    
+def _rphi_frequencyRatio(a, p, e, x):
+    """Ratio of r-frequency and phi-frequency 
+
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    double
+    """
+    a, x = _standardize_params(a, x)
+    
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if x == 0:
+        raise ValueError("Polar orbits not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    if not is_stable(a, p, e, x):
+        raise ValueError("Not a stable orbit")
+    
+    r1, r2, r3, r4 = stable_radial_roots(a, p, e, x)
+    z_minus, z_plus = stable_polar_roots(a, p, e, x)
+    E, L, Q = constants_of_motion(a, p, e, x)
+    
+    r_plus = 1 + sqrt(1 - a**2)
+    r_minus = 1 - sqrt(1 - a**2)
+
+    k_r = sqrt((r1 - r2) * (r3 - r4) / ((r1 - r3) * (r2 - r4)))
+    k_theta = sqrt(z_minus / z_plus)
+    h_plus = (r1 - r2) * (r3 - r_plus) / ((r1 - r3) * (r2 - r_plus))
+    h_minus = (r1 - r2) * (r3 - r_minus) / ((r1 - r3) * (r2 - r_minus))
+    
+    # simplified form of epsilon0*z_plus
+    e0zp = (a**2 * (1 - E**2) * (1 - z_minus) + L**2) / (L**2 * (1 - z_minus))
+    
+    #theta-r ratio
+    y1 = (p**2-p*(r3+r4))/(1-e**2)+r3*r4
+    y2 = a**2/2*(2*z_plus-z_minus)
+    d1 = e*p*(r4-r3)/(1-e**2)
+    d2 = -a**2*z_minus/2
+    thetar_ratio = sign(x)*sqrt(y2/y1)*elliprf(0, 1+d1/y1,1-d1/y1)/elliprf(0, 1+d2/y2, 1-d2/y2)
+    
+    #coefficients
+    Btheta = 2 / (pi * sqrt(e0zp)) * _ellippi(z_minus, k_theta**2)
+    Br = 2 * a / (
+        pi * (r_plus - r_minus) * sqrt((1 - E**2) * (r1 - r3) * (r2 - r4))
+    ) * (
+        (2 * E * r_plus - a * L)
+        / (r3 - r_plus)
+        * (ellipk(k_r**2) - (r2 - r3) / (r2 - r_plus) * _ellippi(h_plus, k_r**2))
+        - (2 * E * r_minus - a * L)
+        / (r3 - r_minus)
+        * (ellipk(k_r**2) - (r2 - r3) / (r2 - r_minus) * _ellippi(h_minus, k_r**2))
+    )
+    return 1/(Btheta*thetar_ratio+Br)
+
+def _phitheta_frequencyRatio(a, p, e, x):
+    """Ratio of r-frequency and phi-frequency 
+
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    double
+    """
+    a, x = _standardize_params(a, x)
+    
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if x == 0:
+        raise ValueError("Polar orbits not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    if not is_stable(a, p, e, x):
+        raise ValueError("Not a stable orbit")
+    
+    r1, r2, r3, r4 = stable_radial_roots(a, p, e, x)
+    z_minus, z_plus = stable_polar_roots(a, p, e, x)
+    E, L, Q = constants_of_motion(a, p, e, x)
+    
+    r_plus = 1 + sqrt(1 - a**2)
+    r_minus = 1 - sqrt(1 - a**2)
+
+    k_r = sqrt((r1 - r2) * (r3 - r4) / ((r1 - r3) * (r2 - r4)))
+    k_theta = sqrt(z_minus / z_plus)
+    h_plus = (r1 - r2) * (r3 - r_plus) / ((r1 - r3) * (r2 - r_plus))
+    h_minus = (r1 - r2) * (r3 - r_minus) / ((r1 - r3) * (r2 - r_minus))
+    
+    # simplified form of epsilon0*z_plus
+    e0zp = (a**2 * (1 - E**2) * (1 - z_minus) + L**2) / (L**2 * (1 - z_minus))
+    
+    #theta-r ratio
+    y1 = (p**2-p*(r3+r4))/(1-e**2)+r3*r4
+    y2 = a**2/2*(2*z_plus-z_minus)
+    d1 = e*p*(r4-r3)/(1-e**2)
+    d2 = -a**2*z_minus/2
+    rtheta_ratio = sign(x)*sqrt(y1/y2)*elliprf(0, 1+d2/y2,1-d2/y2)/elliprf(0, 1+d1/y1, 1-d1/y1)
+    
+    #coefficients
+    Btheta = 2 / (pi * sqrt(e0zp)) * _ellippi(z_minus, k_theta**2)
+    Br = 2 * a / (
+        pi * (r_plus - r_minus) * sqrt((1 - E**2) * (r1 - r3) * (r2 - r4))
+    ) * (
+        (2 * E * r_plus - a * L)
+        / (r3 - r_plus)
+        * (ellipk(k_r**2) - (r2 - r3) / (r2 - r_plus) * _ellippi(h_plus, k_r**2))
+        - (2 * E * r_minus - a * L)
+        / (r3 - r_minus)
+        * (ellipk(k_r**2) - (r2 - r3) / (r2 - r_minus) * _ellippi(h_minus, k_r**2))
+    )
+    return Btheta+Br*rtheta_ratio
+
+# Finding resonance
+## In general 
+def rtheta_resonance(ratio, a, e, x):
+    """Return p of r-theta resonant orbit
+    
+    Parameters
+    ----------
+    ratio: double
+        r-theta frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    """
+    
+    a, x = _standardize_params(a, x)
+    
+    if not valid_frequencyRatio(ratio):
+        raise ValueError("The ratio must be between 0 and 1")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if x == 0:
+        raise ValueError("Polar orbits not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    
+    try:
+        p0 = 6/(1-ratio**2)
+        p1 = separatrix(a, e, x)+1e-10
+        p_sol = newton(lambda p: abs(_rtheta_frequencyRatio(a, p, e, x))-ratio, x0=p0, x1=p1)
+    except ValueError:
+        p0 = separatrix(a, e, x)+1e-10
+        p_sol = newton(lambda p: abs(_rtheta_frequencyRatio(a, p, e, x))-ratio, x0=p0)
+        return p_sol    
+    else:
+        return p_sol
+
+def rphi_resonance(ratio, a, e, x):
+    """Return p of r-phi resonant orbit
+
+    Parameters
+    ----------
+    ratio: double
+        r-phi frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    """
+    
+    a, x = _standardize_params(a, x)
+    
+    if not valid_frequencyRatio(ratio):
+        raise ValueError("The ratio must be between 0 and 1")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if x == 0:
+        raise ValueError("Polar orbits not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+
+    try:
+        p0 = 6/(1-ratio**2)
+        p1 = separatrix(a, e, x)+1e-10
+        p_sol = newton(lambda p: abs(_rphi_frequencyRatio(a, p, e, x))-ratio, x0=p0, x1=p1)
+    except ValueError:
+        p0 = separatrix(a, e, x)+1e-10
+        p_sol = newton(lambda p: abs(_rphi_frequencyRatio(a, p, e, x))-ratio, x0=p0)
+        return p_sol    
+    else:
+        return p_sol
+
+def phitheta_resonance(ratio, a, e, x):
+    """Return p of phi-theta resonant orbit
+
+    Parameters
+    ----------
+    ratio: double
+        r-phi frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    """
+    
+    a, x = _standardize_params(a, x)
+    
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if x == 0:
+        raise ValueError("Polar orbits not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+
+    k = ratio**2
+    p0 = separatrix(a, e, x)+1e-10
+    p_sol = newton(lambda p: abs(_phitheta_frequencyRatio(a, p, e, x))-ratio, x0=p0)
+    return p_sol
+
+## In the weak-field limit (only r-theta and r-phi)
+def rtheta_resonance_weakFieldLimit(ratio, a, p, e):
+    """Return approximated cos^2(theta) of r-theta resonant orbit in the weak-field limit
+
+    Parameters
+    ----------
+    ratio: double
+        r-phi frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    """
+    a = abs(a)
+    
+    if not valid_frequencyRatio(ratio):
+        raise ValueError("The ratio must be between 0 and 1")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, .5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    
+    p0 = 6/(1-ratio**2)
+    return (
+        (4 * a**2 + e**2 - (6 * e**2 + 4 * p**2) / p0) / (a**2 * (5 - 6 * e**2 / p0)) 
+        - (12 * p * (2 * e**2 / p0 + 1)) / (a**2 * (5 - 6 * e**2 / p0)**2)
+        + (8 / a**2) * np.sqrt(
+            (p * (a**2 - e**2 + (6 * e**2 * (1 - a**2) + 4 * p**2) / p0)) / (5 - 6 * e**2 / p0)**3 
+            - (4 * p**2 * (1 - 6 * e**2 / p0)) / (5 - 6 * e**2 / p0)**4
+        ))
+
+def rphi_resonance_weakFieldLimit(ratio, a, p, e):
+    """Return approximated p of r-phi resonant orbit in the weak-field limit
+
+    Parameters
+    ----------
+    ratio: double
+        r-phi frequency ratio
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    x : double
+        cosine of the orbital inclination
+
+    Returns
+    -------
+    p : double
+        orbital semi-latus rectum
+    """
+    
+    a, x = _standardize_params(a, x)
+    
+    if not valid_frequencyRatio(ratio):
+        raise ValueError("The ratio must be between 0 and 1")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if x == 0:
+        raise ValueError("Polar orbits not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, x):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    
+    p0 = 6/(1-ratio**2)
+    k_rtheta = lambda p: abs((2*(-6+p)*p+24*a*sqrt(p)*x
+                          +3*a**2*(1-5*x**2+e**2*(-1+x**2))
+                          )/(
+                              2*p**2+3*e**2*(1+a**2*(-1+x**2))))
+    equation = lambda p: 1/abs(sign(x)/sqrt(k_rtheta(p))+2*a/p**(3/2)+(-a**2*x-5*e**2*a**2*x/4)/p**2)-ratio
+    p_sol = newton(equation, x0=p0)
+    return p_sol
+    
+# Frequency ratio of r-theta and r-phi in special limits (support finding triple resonance)
+## In the polar limit
+def rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde=True):
+    """Ratio of r-frequency and theta-frequency in the polar limit
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+
+    Returns
+    -------
+    double
+    """
+    Lz_sign = -1+2*int(is_prograde)
+    P = (a**2*(a**4*(-1+e**2)*2+p**4+2*a**2*p*(-2+p+e**2*(2+p)))
+         )/(
+             a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
+    S = (2*(a**2*(-1+e**2)+p**2)**2
+         )/(
+            a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
+    r1 = p/(1-e)
+    r2 = p/(1+e)
+    r3 = (S+sqrt(S**2-4*P))/2
+    r4 = (S-sqrt(S**2-4*P))/2
+    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
+    Q = 2*p**2*P/(a**2*(2*p+S-e**2*S))
+    #L2 = 0
+    #z2 = 1
+    #z1 = Q/(1-E2)/a**2/z2
+    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
+    k_theta = (1-E2)*a**2/Q
+    factor = Lz_sign*sqrt((r1-r3)*(r2-r4)*2*(1-e**2)*a**2/(2*p**2*P))
+    return factor*ellipk(k_theta)/ellipk(k_r)
+
+def rphi_frequencyRatio_polarLimit(a, p, e, is_prograde=True):
+    """Ratio of r-frequency and phi-frequency in the polar limit
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+
+    Returns
+    -------
+    double
+    """
+    Lz_sign = -1+2*int(is_prograde)
+    P = (a**2*(a**4*(-1+e**2)*2+p**4+2*a**2*p*(-2+p+e**2*(2+p)))
+         )/(
+             a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
+    S = (2*(a**2*(-1+e**2)+p**2)**2
+         )/(
+            a**4*(-1+e**2)**2+2*a**2*(1+e**2)*p**2+(-4+p)*p**3)
+    r1 = p/(1-e)
+    r2 = p/(1+e)
+    r3 = (S+sqrt(S**2-4*P))/2
+    r4 = (S-sqrt(S**2-4*P))/2
+    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
+    Q = 2*p**2*P/(a**2*(2*p+S-e**2*S))
+    #L2 = 0
+    #z2 = 1
+    #z1 = Q/(1-E2)/a**2/z2
+    
+    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
+    k_theta = (1-E2)*a**2/Q
+    factor1 = Lz_sign*sqrt((r1-r3)*(r2-r4)*2*(1-e**2)*a**2/(2*p**2*P))
+    rtheta_ratio = factor1*ellipk(k_theta)/ellipk(k_r)
+    
+    r_plus = 1+sqrt(1-a**2)
+    r_minus = 1-sqrt(1-a**2)
+    h_r = (r1-r2)/(r1-r3)
+    h_plus = h_r*(r3-r_plus)/(r2-r_plus)
+    h_minus = h_r*(r3-r_minus)/(r2-r_minus)
+    factor2 = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E2)*(r1-r3)*(r2-r4)))*2*sqrt(E2)
+    B_r_plus = r_plus/(r3-r_plus)*(ellipk(k_r)-(r2-r3)/(r2-r_plus)*_ellippi(h_plus, k_r))
+    B_r_minus = r_minus/(r3-r_minus)*(ellipk(k_r)-(r2-r3)/(r2-r_minus)*_ellippi(h_minus, k_r))
+    B_r = factor2*(B_r_plus-B_r_minus)
+    #B_theta = 1
+    return 1/(B_r+1/rtheta_ratio)
+
+## In the equatorial limit
+def rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
+    """Ratio of r-frequency and theta-frequency in the equatorial limit
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+
+    Returns
+    -------
+    double
+    """
+    
+    Lz_sign = -1+2*int(is_prograde)
+    P = 0
+    S = 2*(a**4*(-1+e**2)*p+(-4+p)*p**3+a**2*p**2*(3+e**2+p)
+           -Lz_sign*2*sqrt(a**2*p**3*(a**4*(-1+e**2)**2+(-4*e**2+(-2+p)**2)*p**2+2*a**2*p*(-2+p+e**2*(2+p))))
+           )/(
+               a**4*(-1+e**2)**2+(-4+p)**2*p**2+2*a**2*(-1+e**2)*p*(4+p)
+           )
+    P = 0
+    r1 = p/(1-e)
+    r2 = p/(1+e)
+    r3 = (S+sqrt(S**2-4*P))/2
+    r4 = (S-sqrt(S**2-4*P))/2
+    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
+    L2 = (2*(a**2*(-1+e**2)+p**2)*(a**2-P)+4*a**2*p*S)/(a**2*(2*p+S-e**2*S))
+    #Q = 0
+    #z_minus = 0
+    z_plus = -(p**2+2*p*S)/(a**2*(-1+e**2))
+    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
+    k_theta = 0
+    factor = Lz_sign*sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))
+    return factor*ellipk(k_theta)/ellipk(k_r)
+
+def rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde=True):
+    """Ratio of r-frequency and phi-frequency in the equatorial limit
+    
+    Parameters
+    ----------
+    a : double
+        dimensionless spin of the black hole
+    p : double
+        orbital semi-latus rectum
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+
+    Returns
+    -------
+    double
+    """
+    Lz_sign = -1+2*int(is_prograde)
+    P = 0
+    S = 2*(a**4*(-1+e**2)*p+(-4+p)*p**3+a**2*p**2*(3+e**2+p)
+           -Lz_sign*2*sqrt(a**2*p**3*(a**4*(-1+e**2)**2+(-4*e**2+(-2+p)**2)*p**2+2*a**2*p*(-2+p+e**2*(2+p))))
+           )/(
+               a**4*(-1+e**2)**2+(-4+p)**2*p**2+2*a**2*(-1+e**2)*p*(4+p)
+           )
+    P = 0
+    r1 = p/(1-e)
+    r2 = p/(1+e)
+    r3 = (S+sqrt(S**2-4*P))/2
+    r4 = (S-sqrt(S**2-4*P))/2
+    E2 = 1+2*(-1+e**2)/(2*p+S-e**2*S)
+    L2 = (2*(a**2*(-1+e**2)+p**2)*(a**2-P)+4*a**2*p*S)/(a**2*(2*p+S-e**2*S))
+    #Q = 0
+    z_minus = 0
+    z_plus = -(p**2+2*p*S)/(a**2*(-1+e**2))
+    k_r = (r1-r2)/(r1-r3)*(r3-r4)/(r2-r4)
+    k_theta = 0
+    factor1 = Lz_sign*sqrt((r1-r3)*(r2-r4)/(a**2*z_plus))
+    rtheta_ratio = factor1*ellipk(k_theta)/ellipk(k_r)
+
+    r_plus = 1+sqrt(1-a**2)
+    r_minus = 1-sqrt(1-a**2)
+    h_r = (r1-r2)/(r1-r3)
+    h_plus = h_r*(r3-r_plus)/(r2-r_plus)
+    h_minus = h_r*(r3-r_minus)/(r2-r_minus)
+    factor2 = 2*a/(pi*(r_plus-r_minus)*sqrt((1-E2)*(r1-r3)*(r2-r4)))
+    B_theta = 2*_ellippi(z_minus, k_theta)*sqrt(L2)/(pi*sqrt((1-E2)*a**2*z_plus))
+    B_r_plus = (2*sqrt(E2)*r_plus-Lz_sign*a*sqrt(L2))/(r3-r_plus)*(ellipk(k_r)-(r2-r3)/(r2-r_plus)*_ellippi(h_plus, k_r))
+    B_r_minus = (2*sqrt(E2)*r_minus-Lz_sign*a*sqrt(L2))/(r3-r_minus)*(ellipk(k_r)-(r2-r3)/(r2-r_minus)*_ellippi(h_minus, k_r))
+    B_r = factor2*(B_r_plus-B_r_minus)
+    return 1/(B_r+B_theta/rtheta_ratio)    
+
+# Finding triple resonance
+def tripleResonance_phiMode(rMode, thetaMode, a, e, is_prograde=True):
+    """Find possible phi resonant modes from r-mode and theta-mode.
+
+    Parameters
+    ----------
+    rMode : double
+        radial mode
+    thetaMode : double
+        polar-angle mode
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+    
+    Returns
+    ------- 
+    (double, double)
+        Boundaries of the posible phi-mode.
+    """
+        
+    a = abs(a)
+    rtheta_ratio = thetaMode/rMode
+    Lz_sign = int(is_prograde)*2-1
+    
+    if not valid_frequencyRatio(rtheta_ratio):
+        raise ValueError("r-mode must be larger than theta-mode")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, 0.5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    
+    p1 = newton(lambda p: abs(rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rtheta_ratio,
+                6/(1-rtheta_ratio**2))
+    p2 = newton(lambda p: abs(rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-rtheta_ratio,
+                6/(1-rtheta_ratio**2))
+    k1 = newton(lambda rphi_ratio: abs(rphi_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))-rphi_ratio,
+                rtheta_ratio)
+    k2 = newton(lambda rphi_ratio: abs(rphi_frequencyRatio_polarLimit(a, p2, e, is_prograde))-rphi_ratio,
+                rtheta_ratio)
+    
+    return sorted([k1*rMode, k2*rMode])
+
+def tripleResonance_thetaMode(rMode, phiMode, a, e, is_prograde=True):
+    """Find possible theta resonant modes from r-mode and phi-mode.
+
+    Parameters
+    ----------
+    rMode : double
+        radial mode
+    phiMode : double
+        azimuthal-angle mode
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+    
+    Returns
+    ------- 
+    (double, double)
+        Boundaries of the posible theta-mode.
+    """
+        
+    a = abs(a)
+    rphi_ratio = phiMode/rMode
+    Lz_sign = int(is_prograde)*2-1
+    
+    if not valid_frequencyRatio(rphi_ratio):
+        raise ValueError("r-mode must be larger than phi-mode")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, 0.5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")
+    
+    p1 = newton(lambda p: abs(rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rphi_ratio,
+                6/(1-rphi_ratio**2))
+    p2 = newton(lambda p: abs(rphi_frequencyRatio_polarLimit(a, p, e, is_prograde))-rphi_ratio,
+                6/(1-rphi_ratio**2))
+    k1 = newton(lambda rtheta_ratio: abs(rtheta_frequencyRatio_equatorialLimit(a, p1, e, is_prograde))-rtheta_ratio,
+                rphi_ratio)
+    k2 = newton(lambda rtheta_ratio: abs(rtheta_frequencyRatio_polarLimit(a, p2, e, is_prograde))-rtheta_ratio,
+                rphi_ratio)
+    
+    return sorted([k1*rMode, k2*rMode])
+    
+def tripleResonance(rMode, thetaMode, phiMode, a, e, is_prograde=True):
+    """Find (p, x) from resonant modes
+
+    Parameters
+    ----------
+    rMode : double
+        radial mode
+    thetaMode : double
+        polar-angle mode
+    phiMode : double
+        azimuthal-angle mode
+    a : double
+        dimensionless spin of the black hole
+    e : double
+        orbital eccentricity
+    is_prograde : bool
+        True (default) if the orbit is prograde. Otherwise, the orbit is retrograde
+    
+    Returns
+    ------- 
+    (p, x) : (double, double)
+        Return orbital semi-latus rectum and cosine of the orbital inclination, respectively
+    """
+    
+    a = abs(a)
+    rtheta_ratio = thetaMode/rMode
+    rphi_ratio = phiMode/rMode
+    Lz_sign = int(is_prograde)*2-1
+    
+    
+    if not valid_frequencyRatio(rtheta_ratio):
+        raise ValueError("Require r-mode > theta-mode > 0")
+    if not valid_frequencyRatio(rphi_ratio):
+        raise ValueError("Require r-mode > phi-mode > 0")
+    if a == 1:
+        raise ValueError("Extreme Kerr not supported")
+    if e == 1:
+        raise ValueError("Marginally bound orbits not supported")
+    if not valid_params(a, e, 0.5):
+        raise ValueError("a^2, e and x^2 must be between 0 and 1")  
+
+    p1_rtheta = newton(lambda p: abs(rtheta_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rtheta_ratio,
+                       6/(1-rtheta_ratio**2))
+    p2_rtheta = newton(lambda p: abs(rtheta_frequencyRatio_polarLimit(a, p, e, is_prograde))-rtheta_ratio,
+                       6/(1-rtheta_ratio**2))
+    p1_rphi = newton(lambda p: abs(rphi_frequencyRatio_equatorialLimit(a, p, e, is_prograde))-rphi_ratio,
+                    6/(1-rphi_ratio**2))
+    p2_rphi = newton(lambda p: abs(rphi_frequencyRatio_polarLimit(a, p, e, is_prograde))-rphi_ratio,
+                    6/(1-rphi_ratio**2))
+
+    check_if_having_solution = (p1_rtheta-p1_rphi)*(p2_rtheta-p2_rphi)
+
+    
+    if (check_if_having_solution > 0) | (check_if_having_solution == nan):
+        return [nan, nan]
+
+    elif check_if_having_solution < 0:
+        if abs(p1_rtheta-p1_rphi) < abs(p2_rtheta-p2_rphi):
+            p0 = (p1_rtheta+p1_rphi)/2
+        else: 
+            p0 = (p2_rtheta+p2_rphi)/2
+        x0 = Lz_sign*0.5
+        sol = fsolve(lambda X: [abs(_rtheta_frequencyRatio(a, X[0], e, X[1]))-rtheta_ratio,
+                                abs(_rphi_frequencyRatio(a, X[0], e, X[1]))-rphi_ratio], [p0, x0])
+        return sol
+    
+    else:
+        if (p1_rtheta-p1_rphi) == 0:
+            return [p1_rtheta, Lz_sign]
+        else:
+            return [p2_rtheta, 0]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="kerrgeopy",
-    version="0.9.3",
+    version="0.9.4",
     author="Seyong Park",
     description="Library for computing stable and plunging geodesics in Kerr spacetime",
     long_description=long_description,


### PR DESCRIPTION
I implemented some calculation of finding resonance in a new module resonance.py, include:
- Finding p of $r\text{-}\theta$, $r\text{-}\phi$ and $\phi\text{-}\theta$ resonant orbit
- Finding possible $\phi$-modes, $\theta$-modes or $r$-modes for triple resonance with 2 given other modes so that 
$mode_r\cdot\omega_r=mode_\theta\cdot\omega_\theta=mode_\phi\cdot\omega_\phi$
-  ~Finding $z_-^2$ of  $r\text{-}\theta$ and $r\text{-}\phi$ resonant orbit in the weak-field~ (deleted because they are't needed)
- Frequency ratio of $r\text{-}\theta$, $r\text{-}\phi$ and $\phi\text{-}\theta$ in the equatorial limit and polar limit (used for finding triple resonance)